### PR TITLE
Add Claude Code plugin with MCP integration and skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "orbnet",
+  "metadata": {
+    "description": "Network quality monitoring via Orb sensors"
+  },
+  "owner": {
+    "name": "Brian Connelly",
+    "email": "bdc@bconnelly.net"
+  },
+  "plugins": [
+    {
+      "name": "orbnet",
+      "description": "Real-time network quality monitoring via Orb sensors. Provides MCP tools to query scores, responsiveness, speed, web performance, and Wi-Fi link metrics, plus skills for guided network analysis and Wi-Fi diagnostics.",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/briandconnelly/orbnet.git"
+      },
+      "category": "monitoring"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "orbnet",
+  "version": "0.2.0",
+  "description": "Network quality monitoring via Orb sensors — MCP tools and analysis skills",
+  "author": {
+    "name": "Brian Connelly",
+    "email": "bdc@bconnelly.net"
+  },
+  "homepage": "https://github.com/briandconnelly/orbnet"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ NOTES.md
 # pytest-cov db
 .coverage
 .coverage.xml
+
+# Plugin settings (user-specific Orb sensor config)
+.claude/settings.local.json
+orbs.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "orbnet": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "orbnet[mcp]",
+        "orbnet-mcp"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -386,6 +386,39 @@ except httpx.HTTPStatusError as e:
 `orbnet` includes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that allows Claude and other LLM applications to access your Orb network data.
 
 
+### Claude Code
+
+**Step 1 — Install the plugin**
+
+```bash
+claude plugin marketplace add briandconnelly/orbnet
+claude plugin install orbnet@orbnet
+```
+
+This installs the plugin user-wide. Add `--scope project` to limit installation to the current project.
+
+**Step 2 — Configure your Orbs** *(optional, but recommended if you have multiple sensors)*
+
+Create `orbs.json` in your project root to name and address your sensors (this file is gitignored):
+
+```json
+{
+  "default": "home",
+  "orbs": {
+    "home":   { "host": "192.168.1.100", "port": 7080 },
+    "office": { "host": "192.168.1.101", "port": 7080 }
+  }
+}
+```
+
+If you only have one Orb running on the default `localhost:7080`, no configuration file is needed.
+
+**What you get**
+
+- MCP tools (`get_scores_1m`, `get_responsiveness`, `get_wifi_link`, etc.) available in every Claude Code session
+- Skills for guided network analysis and Wi-Fi diagnostics that auto-activate on relevant questions
+
+
 ### Claude Desktop Configuration
 
 Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ if wifi_data:
         print("Weak signal — consider moving closer to the access point")
 ```
 
+> **Orb Cloud API:** Subscribers on [Cloud Plus, Business, or Enterprise](https://orb.net/plans) plans have access to the [Orb Cloud API](https://orb.net/docs/integrations/api), which enables more powerful device management, real-time data streaming, and more.
+
 ## Configuration
 
 ### Client Options

--- a/skills/network-quality/SKILL.md
+++ b/skills/network-quality/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: Orb Network Quality Analysis
+description: This skill should be used when the user asks about network quality, internet performance, Orb scores, connection health, latency, jitter, packet loss, speed test results, web performance, Wi-Fi signal strength, or wireless link quality, or when the user says "analyze my network", "check my internet", "why is my internet slow", "is my connection good for video calls", "show me my network history", "what's my Orb score", "troubleshoot my internet", "what's my Wi-Fi signal strength", "check my RSSI", or "analyze my Wi-Fi channel", or when analyzing data from the orbnet MCP tools (get_scores_1m, get_responsiveness, get_speed_results, get_web_responsiveness, get_wifi_link, get_all_datasets, get_client_info).
+---
+
+# Orb Network Quality Analysis
+
+## Overview
+
+The orbnet MCP server exposes tools for fetching real-time and historical network quality data from Orb sensors. Always attribute results to the specific Orb sensor, not the user's own device — an Orb may be monitoring a different network segment.
+
+## Reading Orb Configuration
+
+Before making tool calls, check whether `orbs.json` exists in the project root. If present, read it to discover available Orbs:
+
+```json
+{
+  "default": "living-room",
+  "orbs": {
+    "living-room": { "host": "192.168.1.100", "port": 7080 },
+    "office":       { "host": "192.168.1.101", "port": 7080 }
+  }
+}
+```
+
+When multiple Orbs are configured:
+- Use the `default` field to select the Orb when the user doesn't specify one
+- Ask the user which Orb to query if context is ambiguous
+- Pass `host` and `port` explicitly in each tool call
+
+If no settings file exists, use MCP server defaults (localhost, port 7080), or ask the user for the sensor's address.
+
+## Tool Selection Guide
+
+| Goal | Best Tool | Notes |
+|------|-----------|-------|
+| Quick health check | `get_scores_1m` | Fastest; overall picture |
+| Video/VoIP issues | `get_responsiveness` | Lag, jitter, packet loss |
+| Slow downloads/uploads | `get_speed_results` | Bandwidth focus |
+| Slow web browsing | `get_web_responsiveness` | TTFB and DNS performance |
+| Full diagnosis | `get_all_datasets` | Fetches all datasets in parallel |
+| Wi-Fi signal / channel quality | `get_wifi_link` | RSSI, SNR, phy_mode, channel |
+| Verify sensor connection | `get_client_info` | Check host, port, caller_id |
+
+## Interpreting Orb Scores
+
+The Orb Score (0–100) represents overall network health:
+
+| Score | Rating | Meaning |
+|-------|--------|---------|
+| 90–100 | Excellent | Outstanding performance |
+| 80–89 | Good | Minor room for improvement |
+| 70–79 | OK | Noticeable room for improvement |
+| 50–69 | Fair | Noticeable issues |
+| 0–49 | Poor | Needs attention |
+
+Component scores (responsiveness_score, reliability_score, speed_score) follow the same scale. A low component score identifies exactly where to dig deeper.
+
+## Stateful Polling
+
+The MCP server uses a session-fixed `caller_id` for stateful polling:
+- First call returns all available historical data
+- Subsequent calls in the same session return only new records
+
+To reset polling and retrieve all data again, pass a new UUID as `caller_id`. This is useful when switching Orbs or starting a fresh analysis.
+
+## Responsiveness Thresholds
+
+| Metric | Unit | Good | Fair | Poor |
+|--------|------|------|------|------|
+| `lag_avg_us` | µs | < 20,000 | 20,000–50,000 | > 50,000 |
+| `latency_avg_us` | µs | < 50,000 | 50,000–100,000 | > 100,000 |
+| `jitter_avg_us` | µs | < 10,000 | 10,000–30,000 | > 30,000 |
+| `packet_loss_pct` | % | < 1 | 1–5 | > 5 |
+
+Use `granularity="1s"` for real-time troubleshooting; `"1m"` for trend analysis.
+
+## Speed Test Notes
+
+Speed tests run approximately once per hour. Convert `download_kbps` and `upload_kbps` to Mbps by dividing by 1,000. Compare against the user's subscribed plan when available — if the user hasn't mentioned their plan speed, ask before drawing conclusions about whether results are acceptable.
+
+## Web Responsiveness Thresholds
+
+| Metric | Unit | Good | Poor |
+|--------|------|------|------|
+| `ttfb_us` | µs | < 500,000 (500 ms) | > 1,000,000 (1 s) |
+| `dns_us` | µs | < 50,000 (50 ms) | > 200,000 (200 ms) |
+
+High TTFB suggests server-side or WAN latency; high DNS time suggests a DNS resolver problem.
+
+## Analysis Workflow
+
+For a complete diagnosis:
+
+1. Call `get_scores_1m` to get an overall picture
+2. Check which component scores are low and drill into that dataset
+3. Look for patterns over time — degradation during peak hours suggests congestion
+4. Correlate metrics:
+   - High latency + packet loss → congestion or ISP issue
+   - High jitter → instability, likely affects VoIP and video
+   - Low speed but good responsiveness → bandwidth bottleneck, not latency
+   - Slow DNS but fast TTFB → DNS resolver problem
+   - All scores low → likely upstream WAN or ISP issue
+   - Low speed or high latency + poor RSSI or low `tx_rate_mbps` → wireless layer bottleneck, not WAN
+5. Summarize findings with specific metric values and actionable recommendations
+6. Attribute all findings to the Orb sensor, not the user's device
+
+## Presenting Results
+
+When reporting to the user:
+- Convert microseconds to milliseconds (divide by 1,000) for readability
+- Convert kbps to Mbps (divide by 1,000) for speed values
+- Include timestamps to anchor results in time
+- Lead with the Orb Score and its trend, then drill into specifics
+- End with concrete next steps (e.g., "Check ISP status", "Move device closer to router")
+
+## Additional Resources
+
+For complete field definitions and all available metrics across each dataset, see:
+- **`references/metrics.md`** — Detailed field reference for all datasets

--- a/skills/network-quality/references/metrics.md
+++ b/skills/network-quality/references/metrics.md
@@ -1,0 +1,129 @@
+# Orb Network Metrics Reference
+
+## Scores Dataset (`get_scores_1m`)
+
+1-minute granularity only. Each record represents a 1-minute aggregate.
+
+| Field | Type | Unit | Description |
+|-------|------|------|-------------|
+| `orb_score` | int | 0–100 | Overall network quality score |
+| `responsiveness_score` | int | 0–100 | Responsiveness component score |
+| `reliability_score` | int | 0–100 | Reliability component score |
+| `speed_score` | int | 0–100 | Speed component score |
+| `lag_avg_us` | int | µs | Average lag in microseconds |
+| `download_avg_kbps` | int | kbps | Average download throughput |
+| `upload_avg_kbps` | int | kbps | Average upload throughput |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
+| `isp_name` | str | — | Internet service provider name |
+| `country_code` | str | — | Two-letter ISO country code |
+| `timestamp` | int | epoch ms | Measurement timestamp |
+
+## Responsiveness Dataset (`get_responsiveness`)
+
+Available granularities: `1s`, `15s`, `1m`.
+
+| Field | Type | Unit | Description |
+|-------|------|------|-------------|
+| `lag_avg_us` | int | µs | Average lag (round-trip from device to internet) |
+| `latency_avg_us` | int | µs | Average round-trip latency |
+| `jitter_avg_us` | int | µs | Average jitter (variation in latency) |
+| `packet_loss_pct` | float | % | Percentage of lost packets |
+| `latency_count` | int | — | Number of successful latency measurements |
+| `latency_lost_count` | int | — | Number of lost packets |
+| `router_lag_avg_us` | int | µs | Average lag to local router |
+| `router_latency_avg_us` | int | µs | Average round-trip latency to router |
+| `router_packet_loss_pct` | float | % | Packet loss to router |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
+| `timestamp` | int | epoch ms | Measurement timestamp |
+
+**Lag vs. Latency:** Lag measures time until the first byte response; latency is the full round-trip time. Lag is typically lower than latency.
+
+**Router metrics:** Compares against the local router, not the internet. High router lag can indicate a congested home network; high internet lag with normal router lag points to ISP issues.
+
+## Speed Dataset (`get_speed_results`)
+
+Runs approximately once per hour.
+
+| Field | Type | Unit | Description |
+|-------|------|------|-------------|
+| `download_kbps` | int | kbps | Download speed from speed test |
+| `upload_kbps` | int | kbps | Upload speed from speed test |
+| `speed_test_engine` | str | — | Engine used (e.g., "ookla", "ndt7") |
+| `speed_test_server` | str | — | Server endpoint used |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
+| `timestamp` | int | epoch ms | Test timestamp |
+
+**Unit conversion:** Divide kbps by 1,000 for Mbps.
+
+## Web Responsiveness Dataset (`get_web_responsiveness`)
+
+Runs approximately once per minute.
+
+| Field | Type | Unit | Description |
+|-------|------|------|-------------|
+| `ttfb_us` | int | µs | Time to First Byte for web page load (max 5,000,000) |
+| `dns_us` | int | µs | DNS resolver response time (max 5,000,000) |
+| `web_url` | str | — | URL tested |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
+| `timestamp` | int | epoch ms | Measurement timestamp |
+
+**Max values:** Both `ttfb_us` and `dns_us` cap at 5,000,000 µs (5 seconds), indicating a timeout.
+
+## Wi-Fi Link Dataset (`get_wifi_link`)
+
+Available granularities: `1s`, `15s`, `1m`.
+
+| Field | Type | Unit | Description | Platform |
+|-------|------|------|-------------|----------|
+| `rssi_avg` | float | dBm | Average signal strength | All |
+| `snr_avg` | float | dB | Average signal-to-noise ratio | All |
+| `noise_avg` | float | dBm | Average background RF noise | All |
+| `tx_rate_mbps` | float | Mbps | Transmit link rate | All |
+| `rx_rate_mbps` | float | Mbps | Receive link rate | Not macOS |
+| `phy_mode` | str | — | Wi-Fi standard (802.11n/ac/ax) | All |
+| `channel_band` | str | — | Band (2.4 GHz, 5 GHz, 6 GHz) | All |
+| `channel_number` | int | — | Wi-Fi channel number | All |
+| `frequency_mhz` | int | MHz | Channel center frequency | All |
+| `channel_width` | int | MHz | Channel width | Not Android |
+| `security` | str | — | Security protocol (WPA2, WPA3, etc.) | Not Android |
+| `network_name` | str | — | SSID of connected network | All |
+| `bssid` | str | — | Access point MAC address | All |
+| `mcs` | int | — | Modulation coding scheme index | Linux only |
+| `nss` | int | — | Number of spatial streams | Linux only |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet | All |
+| `timestamp` | int | epoch ms | Measurement timestamp | All |
+
+## `get_all_datasets` Response Structure
+
+Returns an `AllDatasetsResponse` with these keys:
+
+| Key | Content | Notes |
+|-----|---------|-------|
+| `scores_1m` | List of ScoreRecord | Always fetched |
+| `responsiveness_1m` | List of ResponsivenessRecord | Always fetched |
+| `responsiveness_15s` | List of ResponsivenessRecord | Only if `include_all_responsiveness=True` |
+| `responsiveness_1s` | List of ResponsivenessRecord | Only if `include_all_responsiveness=True` |
+| `web_responsiveness` | List of WebResponsivenessRecord | Always fetched |
+| `speed_results` | List of SpeedRecord | Always fetched |
+| `wifi_link_1m` | List of WifiLinkRecord | Always fetched (empty if on ethernet/iOS) |
+| `wifi_link_15s` | List of WifiLinkRecord | Only if `include_all_wifi_link=True` |
+| `wifi_link_1s` | List of WifiLinkRecord | Only if `include_all_wifi_link=True` |
+
+Each value may be a list of records or an error dict `{"error": "..."}` if that dataset failed.
+
+## `network_type` Enum Values
+
+| Value | Meaning |
+|-------|---------|
+| 0 | Unknown |
+| 1 | Wi-Fi |
+| 2 | Ethernet |
+
+## Unit Conversions Quick Reference
+
+| From | To | Operation |
+|------|----|-----------|
+| kbps | Mbps | ÷ 1,000 |
+| µs | ms | ÷ 1,000 |
+| µs | s | ÷ 1,000,000 |
+| epoch ms | human time | Convert using datetime |

--- a/skills/network-quality/references/metrics.md
+++ b/skills/network-quality/references/metrics.md
@@ -48,7 +48,7 @@ Runs approximately once per hour.
 |-------|------|------|-------------|
 | `download_kbps` | int | kbps | Download speed from speed test |
 | `upload_kbps` | int | kbps | Upload speed from speed test |
-| `speed_test_engine` | str | — | Engine used (e.g., "ookla", "ndt7") |
+| `speed_test_engine` | int | enum | Engine used: 0=orb, 1=iperf |
 | `speed_test_server` | str | — | Server endpoint used |
 | `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
 | `timestamp` | int | epoch ms | Test timestamp |

--- a/skills/network-quality/references/metrics.md
+++ b/skills/network-quality/references/metrics.md
@@ -6,14 +6,14 @@
 
 | Field | Type | Unit | Description |
 |-------|------|------|-------------|
-| `orb_score` | int | 0–100 | Overall network quality score |
-| `responsiveness_score` | int | 0–100 | Responsiveness component score |
-| `reliability_score` | int | 0–100 | Reliability component score |
-| `speed_score` | int | 0–100 | Speed component score |
-| `lag_avg_us` | int | µs | Average lag in microseconds |
+| `orb_score` | float | 0–100 | Overall network quality score |
+| `responsiveness_score` | float | 0–100 | Responsiveness component score |
+| `reliability_score` | float | 0–100 | Reliability component score |
+| `speed_score` | float | 0–100 | Speed component score |
+| `lag_avg_us` | float | µs | Average lag in microseconds |
 | `download_avg_kbps` | int | kbps | Average download throughput |
 | `upload_avg_kbps` | int | kbps | Average upload throughput |
-| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet, 3=Other |
 | `isp_name` | str | — | Internet service provider name |
 | `country_code` | str | — | Two-letter ISO country code |
 | `timestamp` | int | epoch ms | Measurement timestamp |
@@ -33,7 +33,7 @@ Available granularities: `1s`, `15s`, `1m`.
 | `router_lag_avg_us` | int | µs | Average lag to local router |
 | `router_latency_avg_us` | int | µs | Average round-trip latency to router |
 | `router_packet_loss_pct` | float | % | Packet loss to router |
-| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet, 3=Other |
 | `timestamp` | int | epoch ms | Measurement timestamp |
 
 **Lag vs. Latency:** Lag measures time until the first byte response; latency is the full round-trip time. Lag is typically lower than latency.
@@ -50,7 +50,7 @@ Runs approximately once per hour.
 | `upload_kbps` | int | kbps | Upload speed from speed test |
 | `speed_test_engine` | int | enum | Engine used: 0=orb, 1=iperf |
 | `speed_test_server` | str | — | Server endpoint used |
-| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet, 3=Other |
 | `timestamp` | int | epoch ms | Test timestamp |
 
 **Unit conversion:** Divide kbps by 1,000 for Mbps.
@@ -64,7 +64,7 @@ Runs approximately once per minute.
 | `ttfb_us` | int | µs | Time to First Byte for web page load (max 5,000,000) |
 | `dns_us` | int | µs | DNS resolver response time (max 5,000,000) |
 | `web_url` | str | — | URL tested |
-| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet, 3=Other |
 | `timestamp` | int | epoch ms | Measurement timestamp |
 
 **Max values:** Both `ttfb_us` and `dns_us` cap at 5,000,000 µs (5 seconds), indicating a timeout.
@@ -84,13 +84,13 @@ Available granularities: `1s`, `15s`, `1m`.
 | `channel_band` | str | — | Band (2.4 GHz, 5 GHz, 6 GHz) | All |
 | `channel_number` | int | — | Wi-Fi channel number | All |
 | `frequency_mhz` | int | MHz | Channel center frequency | All |
-| `channel_width` | int | MHz | Channel width | Not Android |
+| `channel_width` | str | MHz | Channel width | Not Android |
 | `security` | str | — | Security protocol (WPA2, WPA3, etc.) | Not Android |
 | `network_name` | str | — | SSID of connected network | All |
 | `bssid` | str | — | Access point MAC address | All |
 | `mcs` | int | — | Modulation coding scheme index | Linux only |
 | `nss` | int | — | Number of spatial streams | Linux only |
-| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet | All |
+| `network_type` | int | enum | 0=Unknown, 1=Wi-Fi, 2=Ethernet, 3=Other | All |
 | `timestamp` | int | epoch ms | Measurement timestamp | All |
 
 ## `get_all_datasets` Response Structure
@@ -118,6 +118,7 @@ Each value may be a list of records or an error dict `{"error": "..."}` if that 
 | 0 | Unknown |
 | 1 | Wi-Fi |
 | 2 | Ethernet |
+| 3 | Other |
 
 ## Unit Conversions Quick Reference
 

--- a/skills/wifi-diagnostics/SKILL.md
+++ b/skills/wifi-diagnostics/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: Orb Wi-Fi Diagnostics
+description: This skill should be used when the user asks about Wi-Fi signal strength, "is my Wi-Fi good", "why is my Wi-Fi weak or slow", "what Wi-Fi channel am I on", "is there Wi-Fi interference", "my Wi-Fi is fast but internet is slow", "is the problem my Wi-Fi or my ISP", "why does my Wi-Fi drop", "Wi-Fi vs ethernet", or when the get_wifi_link MCP tool is being called or its results are being analyzed. Provides interpretation of Wi-Fi signal metrics (RSSI, SNR, link rates), channel and band analysis, interference diagnosis, and correlation with overall network performance.
+---
+
+# Orb Wi-Fi Diagnostics
+
+## Overview
+
+Wi-Fi Link data measures the wireless connection between the Orb sensor and its access point. Use `get_wifi_link` to analyze signal quality, channel conditions, and link layer performance, then correlate with overall network metrics to distinguish Wi-Fi problems from WAN/ISP issues.
+
+**Availability note:** Wi-Fi Link data is not available when the Orb sensor is connected via ethernet or running on iOS. Some fields are platform-specific — see Platform Caveats below.
+
+## Reading Orb Configuration
+
+Check `orbs.json` in the project root for configured Orbs (see the network-quality skill for format). For Wi-Fi diagnostics, a specific Orb is usually implied by the user's question; ask if ambiguous.
+
+## Fetching Wi-Fi Data
+
+```
+get_wifi_link(granularity="1m")     # trends and analysis
+get_wifi_link(granularity="1s")     # real-time signal fluctuations
+get_wifi_link(granularity="15s")    # balance between resolution and noise
+```
+
+An empty list means the sensor is on ethernet or iOS. Inform the user: this confirms the Orb is not on Wi-Fi, which rules out wireless signal issues as the cause of any reported problems.
+
+## Signal Strength (RSSI)
+
+`rssi_avg` is reported in dBm (decibel-milliwatts). Higher (less negative) is better.
+
+| RSSI (dBm) | Rating | Meaning |
+|------------|--------|---------|
+| > −50 | Excellent | Very strong; full throughput |
+| −50 to −65 | Good | Reliable; typical for most use cases |
+| −65 to −75 | Fair | Usable but degraded throughput likely |
+| −75 to −85 | Poor | Frequent dropouts; unreliable for streaming |
+| < −85 | Very poor | Barely connected; significant packet loss expected |
+
+## Signal-to-Noise Ratio (SNR)
+
+`snr_avg` measures the ratio of signal to background RF noise in dB. Higher is better.
+
+| SNR (dB) | Rating |
+|----------|--------|
+| > 40 | Excellent |
+| 25–40 | Good |
+| 15–25 | Fair — interference likely |
+| < 15 | Poor — performance severely impacted |
+
+Low SNR with acceptable RSSI suggests high background RF noise (interference), not weak signal.
+
+## Link Rates
+
+`tx_rate_mbps` (transmit) and `rx_rate_mbps` (receive) indicate the negotiated wireless link speed.
+
+- Link rate is the **maximum possible** throughput — actual data throughput will be lower
+- Low link rates relative to the Wi-Fi standard indicate poor signal quality
+- 802.11ac (Wi-Fi 5): up to 866 Mbps single-stream, ~1,300 Mbps for 3-stream on 5 GHz (theoretical)
+- 802.11ax (Wi-Fi 6/6E): max ~9,600 Mbps theoretical
+
+If link rates are significantly below the standard's maximum, signal quality is limiting bandwidth.
+
+## Channel and Band Analysis
+
+| Field | Meaning |
+|-------|---------|
+| `channel_band` | 2.4 GHz or 5 GHz (or 6 GHz for Wi-Fi 6E) |
+| `channel_number` | Specific channel in use |
+| `frequency_mhz` | Channel center frequency |
+| `phy_mode` | Wi-Fi standard (802.11n, 802.11ac, 802.11ax, etc.) |
+| `channel_width` | Channel width in MHz (not available on Android) |
+
+**2.4 GHz vs 5 GHz:**
+- 2.4 GHz: longer range, more congestion/interference, max 3 non-overlapping channels
+- 5 GHz: shorter range, less interference, ~25 non-overlapping channels (region-dependent)
+- 6 GHz (Wi-Fi 6E): least congestion, shortest range
+
+**Channel overlap (2.4 GHz):** Channels 1, 6, and 11 are the only non-overlapping ones. If the sensor is on 2.4 GHz channel 3 or 9, it's overlapping with neighboring networks.
+
+## Correlation Patterns
+
+Use these patterns to identify root causes:
+
+| Pattern | Likely Cause | Recommendation |
+|---------|-------------|----------------|
+| Low RSSI + high latency | Device too far from AP | Move sensor or AP closer |
+| Low SNR + packet loss | RF interference | Change channel, use 5 GHz |
+| Low link rate + slow speed | Signal quality bottlenecking | Improve signal (position, obstacles) |
+| Good RSSI/SNR but slow speed | WAN/ISP issue | Check `get_speed_results` vs plan |
+| Intermittent drops | Channel congestion or interference | Scan for neighboring networks |
+
+## Cross-Metric Correlation
+
+Always combine Wi-Fi data with network-level data for conclusive diagnosis:
+
+1. Call `get_wifi_link(granularity="1m")` for signal history
+2. Call `get_responsiveness(granularity="1m")` and look for correlation between low RSSI/SNR periods and high latency or packet loss
+3. Call `get_speed_results` — if speed is low only when RSSI is poor, Wi-Fi is the bottleneck; if speed is consistently low regardless of RSSI, the issue is upstream
+4. Timestamps are in epoch milliseconds — align data from different tools by timestamp to find correlations
+
+**Wi-Fi vs WAN diagnosis:**
+- Low RSSI/SNR *and* poor responsiveness → Wi-Fi is the problem
+- Good RSSI/SNR *but* poor responsiveness → WAN or ISP is the problem
+- Intermittent drops in RSSI *correlating* with latency spikes → wireless instability
+
+## Platform Caveats
+
+| Field | Availability |
+|-------|-------------|
+| `rx_rate_mbps` | Not available on macOS |
+| `security` | Not available on Android |
+| `channel_width` | Not available on Android |
+| `mcs` (modulation coding scheme) | Linux only |
+| `nss` (spatial streams) | Linux only |
+
+Omit unavailable fields gracefully — don't report them as zero or unknown; simply don't include them in the analysis.
+
+## Presenting Wi-Fi Findings
+
+- Report RSSI as "−65 dBm (Good)" with both the value and rating
+- Report SNR as "32 dB (Good)"
+- Always state the band (2.4/5 GHz) and channel — this is immediately actionable
+- If using 2.4 GHz, check if a 5 GHz network is available — recommend switching if signal quality permits
+- End with ranked recommendations: Wi-Fi-layer fixes first, then network-level suggestions
+
+## Additional Resources
+
+For detailed 802.11 standard rates, channel plans, and interference sources:
+- **`references/wifi-metrics.md`** — 802.11 standard reference, channel plans, noise sources

--- a/skills/wifi-diagnostics/references/wifi-metrics.md
+++ b/skills/wifi-diagnostics/references/wifi-metrics.md
@@ -1,0 +1,113 @@
+# Wi-Fi Metrics Reference
+
+## 802.11 Standard Reference
+
+| Standard | Band | Max Theoretical | Notes |
+|----------|------|-----------------|-------|
+| 802.11n (Wi-Fi 4) | 2.4/5 GHz | 600 Mbps | Common on older devices |
+| 802.11ac (Wi-Fi 5) | 5 GHz | 3.5 Gbps (MU-MIMO) | Most common home standard |
+| 802.11ax (Wi-Fi 6) | 2.4/5 GHz | 9.6 Gbps | OFDMA, improved congestion handling |
+| 802.11ax (Wi-Fi 6E) | 6 GHz | 9.6 Gbps | Less congestion, shorter range |
+| 802.11be (Wi-Fi 7) | 2.4/5/6 GHz | 46 Gbps | Multi-link operation |
+
+**Practical note:** Real-world throughput is typically 40–60% of theoretical maximum.
+
+## Channel Plans
+
+### 2.4 GHz Channels (US)
+Channels 1–13 available; only 1, 6, and 11 are non-overlapping.
+
+```
+Ch 1:  2412 MHz  ████
+Ch 2:  2417 MHz   ████   ← overlaps 1 and 3
+Ch 6:  2437 MHz        ████
+Ch 11: 2462 MHz              ████
+```
+
+**Problem pattern:** If `channel_number` is 2, 3, 4, 5, 7, 8, 9, or 10, the sensor is on an overlapping channel — this causes co-channel interference.
+
+### 5 GHz Channels (US, partial)
+
+Non-overlapping 20 MHz channels: 36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112, 116, 132, 136, 140, 149, 153, 157, 161, 165.
+
+5 GHz offers ~25 non-overlapping channels — far less congestion than 2.4 GHz in dense environments.
+
+**Channels 52–144 (DFS channels):** May require radar detection compliance, causing brief channel changes.
+
+### 6 GHz Channels (Wi-Fi 6E/7, US)
+59 non-overlapping 20 MHz channels. Least congested; not backward compatible with older devices.
+
+## Link Rate vs. Throughput
+
+The `tx_rate_mbps` and `rx_rate_mbps` fields show the **negotiated PHY rate**, not actual data throughput. Expect:
+- Real TCP throughput ≈ 40–60% of PHY rate under ideal conditions
+- TCP throughput drops significantly when RSSI < −70 dBm
+
+### Typical PHY Rates by Standard and Signal
+
+| Signal | 802.11n (2.4G) | 802.11ac (5G) | 802.11ax (5G) |
+|--------|----------------|---------------|---------------|
+| Excellent (> −50) | 300 Mbps | 866 Mbps | 1,201 Mbps |
+| Good (−50 to −65) | 150 Mbps | 433 Mbps | 600 Mbps |
+| Fair (−65 to −75) | 54 Mbps | 130 Mbps | 143 Mbps |
+| Poor (< −75) | 6–12 Mbps | 6–54 Mbps | < 100 Mbps |
+
+## MCS (Modulation Coding Scheme) — Linux Only
+
+Higher MCS index = more data per transmission (requires better signal).
+
+| MCS | Modulation | Spatial Streams | Minimum SNR |
+|-----|-----------|-----------------|-------------|
+| 0 | BPSK 1/2 | 1 | ~5 dB |
+| 4 | 16-QAM 3/4 | 1 | ~15 dB |
+| 7 | 64-QAM 5/6 | 1 | ~25 dB |
+| 9 | 256-QAM (802.11ac) | 1 | ~30 dB |
+| 11 | 1024-QAM (802.11ax) | 1 | ~35 dB |
+
+Low MCS index despite good RSSI suggests high noise floor (low SNR).
+
+## NSS (Number of Spatial Streams) — Linux Only
+
+`nss` indicates how many MIMO spatial streams are in use:
+- 1 stream: single-chain connection (lower max speed)
+- 2 streams: common for mid-range devices
+- 3–4 streams: high-end devices / APs
+
+Low NSS on a device that supports multiple streams indicates poor signal or an AP that doesn't support MIMO well.
+
+## Common RF Interference Sources
+
+| Source | Band | Characteristics |
+|--------|------|-----------------|
+| Neighboring Wi-Fi | 2.4/5 GHz | Co-channel or adjacent channel interference |
+| Bluetooth | 2.4 GHz | Frequency hops across 2.4 GHz band |
+| Microwave ovens | 2.4 GHz | Intermittent, typically 2–3 minutes |
+| Baby monitors | 2.4 GHz | Constant while operating |
+| Cordless phones (DECT) | 1.9/5.8 GHz | Variable depending on protocol |
+| ZigBee/Z-Wave | 2.4 GHz | Low power but can degrade SNR |
+
+**Diagnosis:** High `noise_avg` (above −85 dBm) with low SNR indicates an RF-noisy environment, even if RSSI is adequate.
+
+## Noise Floor Reference
+
+`noise_avg` is the background RF noise level in dBm:
+
+| Noise Floor | Environment |
+|------------|-------------|
+| < −95 dBm | Very clean RF environment |
+| −95 to −85 dBm | Normal home/office |
+| −85 to −75 dBm | Congested environment (dense Wi-Fi) |
+| > −75 dBm | High noise; performance will suffer |
+
+## Security Protocols
+
+| `security` Value | Security Level | Notes |
+|------------------|---------------|-------|
+| WPA3 Personal | Best | SPDH, forward secrecy |
+| WPA3 Enterprise | Best | 802.1X authentication |
+| WPA2 Personal | Good | CCMP/AES; vulnerable to PMKID attack |
+| WPA2 Enterprise | Good | 802.1X authentication |
+| WPA Personal | Weak | TKIP; deprecated |
+| WEP | Very weak | Broken; should not be used |
+| Open | None | No encryption |
+

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -376,7 +376,7 @@ async def get_speed_results(
         List of speed test records, each containing:
         - download_kbps: Download speed in kbps
         - upload_kbps: Upload speed in kbps
-        - speed_test_engine: Name of the speed test engine used
+        - speed_test_engine: Speed test engine as integer (0=orb, 1=iperf)
         - speed_test_server: Server used for the speed test
         - timestamp: Test timestamp in epoch milliseconds
         - network_type: Network interface type


### PR DESCRIPTION
## Summary

- Adds a Claude Code plugin (`.claude-plugin/`, `.mcp.json`, `skills/`) that exposes orbnet's MCP tools and guided network-analysis skills within every Claude Code session
- Two skills: **network-quality** (comprehensive analysis) and **wifi-diagnostics** (signal and link-layer troubleshooting)
- Updates `.gitignore` to exclude `orbs.json` (user-specific sensor config) and Claude local settings
- Expands the **MCP Server** section in the README with a new **Claude Code** subsection covering plugin installation and optional multi-Orb `orbs.json` configuration

## Test plan

- [ ] `claude plugin marketplace add briandconnelly/orbnet` resolves correctly
- [ ] `claude plugin install orbnet@orbnet` installs the plugin
- [ ] MCP tools (`get_scores_1m`, `get_responsiveness`, etc.) appear in Claude Code sessions after install
- [ ] Network-quality and Wi-Fi diagnostics skills activate on relevant prompts
- [ ] `orbs.json` is not tracked by git (confirmed in `.gitignore`)
- [ ] README renders correctly — heading hierarchy and code blocks look right

🤖 Generated with [Claude Code](https://claude.com/claude-code)