### PR TITLE
Mcp fixes

### DIFF
--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -487,6 +487,7 @@ class OrbAPIClient:
         caller_id: Optional[str] = None,
         include_all_responsiveness: bool = False,
         include_all_wifi_link: bool = False,
+        default_granularity: Literal["1s", "15s", "1m"] = "1m",
     ) -> AllDatasetsResponse:
         """
         Retrieve all datasets concurrently.
@@ -495,9 +496,12 @@ class OrbAPIClient:
             caller_id: Override the default caller_id for this request
             include_all_responsiveness: If True, fetches all responsiveness
                                        granularities (1s, 15s, 1m). If False,
-                                       only fetches 1m granularity.
+                                       only fetches the default granularity.
             include_all_wifi_link: If True, fetches all Wi-Fi Link granularities
-                                   (1s, 15s, 1m). If False, only fetches 1m.
+                                   (1s, 15s, 1m). If False, only fetches the
+                                   default granularity.
+            default_granularity: Base granularity to fetch when not including all
+                                 granularities (default: '1m').
 
         Returns:
             AllDatasetsResponse object with fields for each dataset type
@@ -558,25 +562,29 @@ class OrbAPIClient:
             include_all_wifi_link=include_all_wifi_link,
         )
 
+        gran = default_granularity
         tasks = {
             "scores_1m": self.get_scores_1m(request.caller_id),
-            "responsiveness_1m": self.get_responsiveness("1m", request.caller_id),
+            f"responsiveness_{gran}": self.get_responsiveness(
+                gran, request.caller_id
+            ),
             "web_responsiveness": self.get_web_responsiveness(request.caller_id),
             "speed_results": self.get_speed_results(request.caller_id),
-            "wifi_link_1m": self.get_wifi_link("1m", request.caller_id),
+            f"wifi_link_{gran}": self.get_wifi_link(gran, request.caller_id),
         }
 
+        all_granularities = {"1s", "15s", "1m"}
+        other_granularities = sorted(all_granularities - {gran})
+
         if request.include_all_responsiveness:
-            tasks["responsiveness_15s"] = self.get_responsiveness(
-                "15s", request.caller_id
-            )
-            tasks["responsiveness_1s"] = self.get_responsiveness(
-                "1s", request.caller_id
-            )
+            for g in other_granularities:
+                tasks[f"responsiveness_{g}"] = self.get_responsiveness(
+                    g, request.caller_id
+                )
 
         if request.include_all_wifi_link:
-            tasks["wifi_link_15s"] = self.get_wifi_link("15s", request.caller_id)
-            tasks["wifi_link_1s"] = self.get_wifi_link("1s", request.caller_id)
+            for g in other_granularities:
+                tasks[f"wifi_link_{g}"] = self.get_wifi_link(g, request.caller_id)
 
         results = await asyncio.gather(*tasks.values(), return_exceptions=True)
 

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -229,7 +229,7 @@ async def get_scores_1m(
 async def get_responsiveness(
     ctx: Context,
     host: Optional[str] = None,
-    granularity: Literal["1s", "15s", "1m"] = "1m",
+    granularity: Literal["1s", "15s", "1m"] = "1s",
     port: Optional[int] = None,
     caller_id: Optional[str] = None,
     timeout: Optional[float] = None,
@@ -397,7 +397,7 @@ async def get_speed_results(
 async def get_wifi_link(
     ctx: Context,
     host: Optional[str] = None,
-    granularity: Literal["1s", "15s", "1m"] = "1m",
+    granularity: Literal["1s", "15s", "1m"] = "1s",
     port: Optional[int] = None,
     caller_id: Optional[str] = None,
     timeout: Optional[float] = None,
@@ -486,10 +486,10 @@ async def get_all_datasets(
 
     Args:
         include_all_responsiveness: If True, fetches all responsiveness granularities
-                                   (1s, 15s, 1m). If False, only fetches 1m. (default:
+                                   (1s, 15s, 1m). If False, only fetches 1s. (default:
                                    False)
         include_all_wifi_link: If True, fetches all Wi-Fi Link granularities
-                               (1s, 15s, 1m). If False, only fetches 1m. (default:
+                               (1s, 15s, 1m). If False, only fetches 1s. (default:
                                False)
         host: Orb sensor hostname or IP (default: from ORB_HOST env var or 'localhost')
         port: API port number (default: from ORB_PORT env var or 7080)
@@ -500,16 +500,16 @@ async def get_all_datasets(
     Returns:
         Dictionary with keys for each dataset type:
         - scores_1m: 1-minute scores dataset
-        - responsiveness_1m: 1-minute responsiveness dataset
+        - responsiveness_1s: 1-second responsiveness dataset
         - responsiveness_15s: 15-second responsiveness
           (if include_all_responsiveness=True)
-        - responsiveness_1s: 1-second responsiveness
+        - responsiveness_1m: 1-minute responsiveness
           (if include_all_responsiveness=True)
         - web_responsiveness: Web responsiveness results
         - speed_results: Speed test results
-        - wifi_link_1m: 1-minute Wi-Fi link dataset (empty list if not on Wi-Fi)
+        - wifi_link_1s: 1-second Wi-Fi link dataset (empty list if not on Wi-Fi)
         - wifi_link_15s: 15-second Wi-Fi link (if include_all_wifi_link=True)
-        - wifi_link_1s: 1-second Wi-Fi link (if include_all_wifi_link=True)
+        - wifi_link_1m: 1-minute Wi-Fi link (if include_all_wifi_link=True)
 
         Each value is either a list of records or an error dict if that dataset failed.
     """
@@ -518,6 +518,7 @@ async def get_all_datasets(
     return await client.get_all_datasets(
         include_all_responsiveness=include_all_responsiveness,
         include_all_wifi_link=include_all_wifi_link,
+        default_granularity="1s",
     )
 
 
@@ -596,7 +597,7 @@ def troubleshoot_slow_internet() -> str:
     return """
     To troubleshoot slow internet:
     1. Call get_speed_results() to check recent speed tests
-    2. Call get_responsiveness(granularity="1m") for latency/jitter data
+    2. Call get_responsiveness() for latency/jitter data
     3. Call get_web_responsiveness() to check TTFB and DNS performance
     4. Compare metrics against typical values:
        - Good latency: < 50ms
@@ -611,7 +612,7 @@ def troubleshoot_wifi() -> str:
     """Diagnose Wi-Fi-specific issues by correlating signal metrics with performance"""
     return """
     To diagnose Wi-Fi-specific network issues:
-    1. Call get_wifi_link(granularity="1m") to get signal and link metrics
+    1. Call get_wifi_link() to get signal and link metrics
     2. Examine key signal indicators:
        - rssi_avg: Signal strength in dBm (good: > -65, poor: < -75)
        - snr_avg: Signal-to-noise ratio in dB (good: > 25, poor: < 15)
@@ -623,7 +624,7 @@ def troubleshoot_wifi() -> str:
        - channel_number: Overlapping channels cause interference
        - phy_mode: Older standards (802.11n) have lower max throughput than
          802.11ac or 802.11ax
-    4. Call get_responsiveness(granularity="1m") to check if poor Wi-Fi signal
+    4. Call get_responsiveness() to check if poor Wi-Fi signal
        correlates with high latency or packet loss
     5. Call get_speed_results() to check if signal weakness is limiting throughput
     6. Correlate the metrics:

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -58,6 +58,16 @@ mcp = FastMCP(
     - 1-minute aggregates for trends
     - Historical data depends on sensor configuration
     - Wi-Fi Link data not available on iOS or ethernet-connected sensors
+    - Not all granularities may be enabled on a given Orb sensor
+
+    **IMPORTANT — Granularity Fallback:**
+    The responsiveness and Wi-Fi link datasets support multiple granularities
+    (1s, 15s, 1m). Each Orb sensor may only have some of these enabled.
+    If a request for a specific granularity returns an error or empty data,
+    you MUST try the other granularities for that same dataset before moving
+    on to a different dataset. The fallback order is: 1s → 15s → 1m.
+    For example, if get_wifi_link(granularity="1s") fails, try "15s",
+    then "1m" before concluding that Wi-Fi link data is unavailable.
 
     **Tool Selection Guide:**
     - Quick check? → get_scores_1m() (fastest, gives overall picture)
@@ -240,6 +250,10 @@ async def get_responsiveness(
     Includes detailed network responsiveness measures including lag, latency,
     jitter, and packet loss. Available in 1-second, 15-second, and 1-minute buckets.
 
+    IMPORTANT: Not all granularities may be enabled on a given Orb sensor. If a
+    request for a specific granularity returns an error or empty data, try the
+    other granularities (1s → 15s → 1m) before giving up on this dataset.
+
     Note on Stateful Polling:
         By default, this tool uses a session-specific caller_id. This means your
         first call returns all available data, and subsequent calls return only
@@ -247,7 +261,7 @@ async def get_responsiveness(
         for updates without receiving duplicate records.
 
     Args:
-        granularity: Time bucket size - '1s', '15s', or '1m' (default: '1m')
+        granularity: Time bucket size - '1s', '15s', or '1m' (default: '1s')
         host: Orb sensor hostname or IP (default: from ORB_HOST env var or 'localhost')
         port: API port number (default: from ORB_PORT env var or 7080)
         caller_id: Unique ID to track polling state. Leave as None to use the default
@@ -413,6 +427,10 @@ async def get_wifi_link(
     Note: Wi-Fi Link data is not available on iOS or when the sensor is
     connected via ethernet.
 
+    IMPORTANT: Not all granularities may be enabled on a given Orb sensor. If a
+    request for a specific granularity returns an error or empty data, try the
+    other granularities (1s → 15s → 1m) before giving up on this dataset.
+
     Note on Stateful Polling:
         By default, this tool uses a session-specific caller_id. This means your
         first call returns all available data, and subsequent calls return only
@@ -420,7 +438,7 @@ async def get_wifi_link(
         for updates without receiving duplicate records.
 
     Args:
-        granularity: Time bucket size - '1s', '15s', or '1m' (default: '1m')
+        granularity: Time bucket size - '1s', '15s', or '1m' (default: '1s')
         host: Orb sensor hostname or IP (default: from ORB_HOST env var or 'localhost')
         port: API port number (default: from ORB_PORT env var or 7080)
         caller_id: Unique ID to track polling state. Leave as None to use the default

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -245,7 +245,10 @@ async def get_responsiveness(
     timeout: Optional[float] = None,
 ) -> List[ResponsivenessRecord]:
     """
-    Retrieve Responsiveness dataset from an Orb sensor.
+    Retrieve Responsiveness dataset from an Orb sensor at a single granularity.
+
+    This tool fetches ONE granularity at a time. To fetch all granularities at
+    once, use get_all_datasets(include_all_responsiveness=True) instead.
 
     Includes detailed network responsiveness measures including lag, latency,
     jitter, and packet loss. Available in 1-second, 15-second, and 1-minute buckets.
@@ -417,7 +420,10 @@ async def get_wifi_link(
     timeout: Optional[float] = None,
 ) -> List[WifiLinkRecord]:
     """
-    Retrieve Wi-Fi Link dataset from an Orb sensor.
+    Retrieve Wi-Fi Link dataset from an Orb sensor at a single granularity.
+
+    This tool fetches ONE granularity at a time. To fetch all granularities at
+    once, use get_all_datasets(include_all_wifi_link=True) instead.
 
     Includes signal quality and link-layer metrics for the active Wi-Fi
     connection: signal strength (RSSI), signal-to-noise ratio (SNR), transmit

--- a/src/orbnet/models.py
+++ b/src/orbnet/models.py
@@ -207,19 +207,30 @@ class ResponsivenessMeasures(BaseModel):
         description="latency_lost_count / (latency_count+latency_loss_count)"
     )
     lag_count: int = Field(description="Lag sample count")
-    router_lag_avg_us: int = Field(description="Avg router lag in microseconds")
-    router_latency_avg_us: int = Field(
-        description="Avg router round trip latency in microseconds"
+    router_lag_avg_us: Optional[int] = Field(
+        default=None, description="Avg router lag in microseconds"
     )
-    router_jitter_avg_us: int = Field(description="Avg router jitter in microseconds")
-    router_latency_count: float = Field(
-        description="Count of router latency measurements that succeeded"
+    router_latency_avg_us: Optional[int] = Field(
+        default=None,
+        description="Avg router round trip latency in microseconds",
     )
-    router_latency_lost_count: int = Field(
-        description="Count of router latency measurements that were lost"
+    router_jitter_avg_us: Optional[int] = Field(
+        default=None, description="Avg router jitter in microseconds"
     )
-    router_packet_loss_pct: float = Field(description="Router packet loss percentage")
-    router_lag_count: int = Field(description="Router lag sample count")
+    router_latency_count: Optional[float] = Field(
+        default=None,
+        description="Count of router latency measurements that succeeded",
+    )
+    router_latency_lost_count: Optional[int] = Field(
+        default=None,
+        description="Count of router latency measurements that were lost",
+    )
+    router_packet_loss_pct: Optional[float] = Field(
+        default=None, description="Router packet loss percentage"
+    )
+    router_lag_count: Optional[int] = Field(
+        default=None, description="Router lag sample count"
+    )
 
 
 class ResponsivenessDimensions(NetworkDimensions):

--- a/src/orbnet/models.py
+++ b/src/orbnet/models.py
@@ -459,12 +459,12 @@ class AllDatasetsResponse(BaseModel):
     """
 
     scores_1m: List[ScoreRecord] | dict
-    responsiveness_1m: List[ResponsivenessRecord] | dict
+    responsiveness_1m: Optional[List[ResponsivenessRecord] | dict] = None
     responsiveness_15s: Optional[List[ResponsivenessRecord] | dict] = None
     responsiveness_1s: Optional[List[ResponsivenessRecord] | dict] = None
     web_responsiveness: List[WebResponsivenessRecord] | dict
     speed_results: List[SpeedRecord] | dict
-    wifi_link_1m: List[WifiLinkRecord] | dict
+    wifi_link_1m: Optional[List[WifiLinkRecord] | dict] = None
     wifi_link_15s: Optional[List[WifiLinkRecord] | dict] = None
     wifi_link_1s: Optional[List[WifiLinkRecord] | dict] = None
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -347,6 +347,27 @@ class TestResponsivenessMeasures:
         assert measures.router_packet_loss_pct == 0.0
         assert measures.router_lag_count == 60
 
+    def test_optional_router_fields(self):
+        """Test that router fields are optional (Orb omits them when unavailable)."""
+        data = {
+            "lag_avg_us": 25000,
+            "latency_avg_us": 30000,
+            "jitter_avg_us": 2000,
+            "latency_count": 60.0,
+            "latency_lost_count": 0,
+            "packet_loss_pct": 0.0,
+            "lag_count": 60,
+        }
+        measures = ResponsivenessMeasures(**data)
+        assert measures.lag_avg_us == 25000
+        assert measures.router_lag_avg_us is None
+        assert measures.router_latency_avg_us is None
+        assert measures.router_jitter_avg_us is None
+        assert measures.router_latency_count is None
+        assert measures.router_latency_lost_count is None
+        assert measures.router_packet_loss_pct is None
+        assert measures.router_lag_count is None
+
 
 class TestWebResponsivenessMeasures:
     """Test WebResponsivenessMeasures model."""


### PR DESCRIPTION
I've been testing the awesome MCP capabilities and have fixed a few bugs I've stumbled upon testing against Sonnet 4.6:

- In instances where the router_ fields in the responsiveness_ datasets are unavailable, the MCP would fail is the data model did not support None values
- Update responsiveness_ and wifi_link_ datasets to default to 1s instead of 1m, as this is the default in the Orb Cloud simple configuration screen
- Instruct the LLM to try the other possible granularities for responsiveness_ and wifi_link_ datasets before moving on to other approaches (e.g. grabbing lag from scores_1m when asked about responsiveness data)
- Sonnet 4.6 was calling get_wifi_link() with the include_all_wifi_link parameter, which is part of the get_all_datasets() signature, not get_wifi_link() -- guide the LLM

All tests pass, and added tests for accepting None for lag values (followed approach used for wifi_link_ None values).

Tested all changes locally with Claude Desktop + Sonnet 4.6.