### PR TITLE
Add prek CI workflow

### DIFF
--- a/.github/workflows/check_coverage.yaml
+++ b/.github/workflows/check_coverage.yaml
@@ -22,7 +22,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run tests
-        run: uv run pytest --cov=./ --cov-branch --cov-report=xml tests
+        run: uv run pytest --cov-branch --cov-report=xml tests
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/check_coverage.yaml
+++ b/.github/workflows/check_coverage.yaml
@@ -1,7 +1,9 @@
 name: Run tests and upload coverage
 
 on:
-  push
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/prek.yaml
+++ b/.github/workflows/prek.yaml
@@ -16,4 +16,4 @@ jobs:
         run: uv sync --all-extras --dev
       - uses: j178/prek-action@v1
         with:
-          extra_args: --all-files --show-diff-on-failure
+          extra_args: --all-files

--- a/.github/workflows/prek.yaml
+++ b/.github/workflows/prek.yaml
@@ -1,0 +1,19 @@
+name: prek
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  prek:
+    name: Run prek checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
+      - name: Install the project
+        run: uv sync --all-extras --dev
+      - uses: j178/prek-action@v1
+        with:
+          extra_args: --all-files --show-diff-on-failure


### PR DESCRIPTION
## Summary
- Add `.github/workflows/prek.yaml` running `j178/prek-action@v1` with `--all-files` so prek hooks (ruff, ty, uv-lock, etc.) run in CI
- Scope `check_coverage.yaml` triggers to pushes on `main` and pull requests, instead of every push on every branch

## Test plan
- [ ] prek workflow runs green on this PR
- [ ] coverage workflow runs on this PR (and continues to upload to Codecov on push to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)