### PR TITLE
Fix CI failures from PR #6 (mcp-fixes)

### DIFF
--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -567,15 +567,13 @@ class OrbAPIClient:
         gran = default_granularity
         tasks = {
             "scores_1m": self.get_scores_1m(request.caller_id),
-            f"responsiveness_{gran}": self.get_responsiveness(
-                gran, request.caller_id
-            ),
+            f"responsiveness_{gran}": self.get_responsiveness(gran, request.caller_id),
             "web_responsiveness": self.get_web_responsiveness(request.caller_id),
             "speed_results": self.get_speed_results(request.caller_id),
             f"wifi_link_{gran}": self.get_wifi_link(gran, request.caller_id),
         }
 
-        all_granularities = {"1s", "15s", "1m"}
+        all_granularities: set[Literal["1s", "15s", "1m"]] = {"1s", "15s", "1m"}
         other_granularities = sorted(all_granularities - {gran})
 
         if request.include_all_responsiveness:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -71,7 +71,9 @@ async def test_get_all_datasets_tool(mock_client, ctx):
     )
     assert result == {}
     mock_client.get_all_datasets.assert_awaited_once_with(
-        include_all_responsiveness=True, include_all_wifi_link=True
+        include_all_responsiveness=True,
+        include_all_wifi_link=True,
+        default_granularity="1s",
     )
 
 


### PR DESCRIPTION
## Summary
- Fix ty type errors at `get_responsiveness` and `get_wifi_link` call sites by annotating `all_granularities` as `set[Literal["1s", "15s", "1m"]]`, so `sorted()` preserves the literal type through iteration.
- Update `test_get_all_datasets_tool` mock assertion to include the `default_granularity="1s"` kwarg now passed by the MCP tool.
- Apply `ruff format` — collapses one wrapped call that now fits on a single line.

All three failures landed on `main` after PR #6 merged without a required green CI gate.

## Test plan
- [x] `uv run pytest tests/ -q` — 101 passed, coverage 100%
- [x] `uv run --with ruff ruff format --check` — clean
- [x] `uv run --with ruff ruff check` — clean
- [x] `uv run --with ty ty check src` — clean
- [ ] Confirm GitHub Actions run green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)