### PR TITLE
Improve prek.toml; fix surfaced ty errors

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -1,35 +1,41 @@
-default_stages = ["pre-commit"]
+default_install_hook_types = ["pre-commit", "pre-push"]
+
+[[repos]]
+repo = "builtin"
+hooks = [
+    { id = "trailing-whitespace" },
+    { id = "end-of-file-fixer" },
+    { id = "check-yaml" },
+    { id = "check-toml" },
+    { id = "check-added-large-files", args = ["--maxkb=500"] },
+    { id = "check-merge-conflict" },
+    { id = "mixed-line-ending", args = ["--fix=lf"] },
+]
 
 [[repos]]
 repo = "https://github.com/pre-commit/pre-commit-hooks"
 rev = "v6.0.0"
 hooks = [
-  { id = "trailing-whitespace" },
-  { id = "end-of-file-fixer" },
-  { id = "check-yaml" },
-  { id = "check-toml" },
-  { id = "check-merge-conflict" },
-  { id = "check-added-large-files" },
-  { id = "mixed-line-ending", args = ["--fix=lf"] },
-]
-
-[[repos]]
-repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.10"
-hooks = [
-  { id = "ruff-check", args = ["--fix"] },
-  { id = "ruff-format" },
+    { id = "debug-statements" },
 ]
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = "0.11.6"
+rev = "0.11.8"
 hooks = [
-  { id = "uv-lock" },
+    { id = "uv-lock" },
+]
+
+[[repos]]
+repo = "https://github.com/astral-sh/ruff-pre-commit"
+rev = "v0.15.12"
+hooks = [
+    { id = "ruff-check", args = ["--fix"] },
+    { id = "ruff-format" },
 ]
 
 [[repos]]
 repo = "local"
 hooks = [
-  { id = "ty", name = "ty (type check src)", language = "system", entry = "uv run ty check src", pass_filenames = false, types = ["python"] },
+    { id = "ty", name = "ty check", entry = "uv run ty check", language = "system", types_or = ["python", "toml"], pass_filenames = false, files = "^(src/.*\\.py$|tests/.*\\.py$|pyproject\\.toml$)", stages = ["pre-push"] },
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,7 +243,7 @@ def mock_httpx_get(mock_httpx_client, mock_httpx_response):
 @pytest.fixture
 def mock_httpx_client_context(mock_httpx_client):
     """Mock httpx.AsyncClient context manager."""
-    with pytest.Mock() as mock_context:
+    with MagicMock() as mock_context:
         mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_httpx_client)
         mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
         return mock_context

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -117,10 +117,10 @@ class TestIntegration:
 
         # Test invalid configuration
         with pytest.raises(ValidationError):
-            OrbClientConfig(port=0)  # Invalid port
+            OrbClientConfig(host="test-host", port=0)  # Invalid port
 
         with pytest.raises(ValidationError):
-            OrbClientConfig(timeout=-1.0)  # Invalid timeout
+            OrbClientConfig(host="test-host", timeout=-1.0)  # Invalid timeout
 
         # Test valid configuration
         config = OrbClientConfig(host="192.168.1.100", port=8080, timeout=30.0)
@@ -192,7 +192,7 @@ class TestIntegration:
             "channel_band": "2.4 GHz",
             "network_type": 1,
         }
-        record = WifiLinkRecord(**minimal_data)
+        record = WifiLinkRecord.model_validate(minimal_data)
 
         # Platform-specific optional fields default to None
         assert record.rx_rate_mbps is None
@@ -219,7 +219,7 @@ class TestIntegration:
     def test_wifi_link_record_extra_fields_integration(self, sample_wifi_link_data):
         """Test WifiLinkRecord accepts extra fields and exposes them via model_extra."""
         data = {**sample_wifi_link_data[0], "unknown_field": "some_value"}
-        record = WifiLinkRecord(**data)
+        record = WifiLinkRecord.model_validate(data)
 
         assert record.model_extra is not None
         assert "unknown_field" in record.model_extra

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -91,16 +91,19 @@ def test_get_client_info_tool(mock_client):
 
 def test_analyze_network_quality_prompt():
     text = mcp_server.analyze_network_quality.fn()
+    assert isinstance(text, str)
     assert "get_scores_1m" in text
 
 
 def test_troubleshoot_slow_internet_prompt():
     text = mcp_server.troubleshoot_slow_internet.fn()
+    assert isinstance(text, str)
     assert "get_speed_results" in text
 
 
 def test_troubleshoot_wifi_prompt():
     text = mcp_server.troubleshoot_wifi.fn()
+    assert isinstance(text, str)
     assert "get_wifi_link" in text
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -88,11 +88,12 @@ class TestDatasetRequestParams:
 
     def test_custom_values(self):
         """Test custom parameter values."""
-        params = DatasetRequestParams(
-            caller_id="test-caller", extra_param="extra_value"
+        params = DatasetRequestParams.model_validate(
+            {"caller_id": "test-caller", "extra_param": "extra_value"}
         )
         assert params.caller_id == "test-caller"
-        assert params.extra_param == "extra_value"
+        assert params.model_extra is not None
+        assert params.model_extra["extra_param"] == "extra_value"
 
 
 class TestResponsivenessRequestParams:
@@ -119,7 +120,7 @@ class TestResponsivenessRequestParams:
 
         # Invalid granularity
         with pytest.raises(ValidationError):
-            ResponsivenessRequestParams(granularity="5m")
+            ResponsivenessRequestParams.model_validate({"granularity": "5m"})
 
 
 class TestAllDatasetsRequestParams:
@@ -223,7 +224,7 @@ class TestScoreIdentifiers:
             "score_version": "1.0.0",
             "orb_version": "2.1.0",
         }
-        identifiers = ScoreIdentifiers(**data)
+        identifiers = ScoreIdentifiers.model_validate(data)
         assert identifiers.orb_id == "test-orb-123"
         assert identifiers.orb_name is None
         assert identifiers.device_name is None
@@ -232,7 +233,7 @@ class TestScoreIdentifiers:
     def test_missing_required_fields(self):
         """Test missing required fields."""
         with pytest.raises(ValidationError):
-            ScoreIdentifiers(orb_id="test-orb-123")
+            ScoreIdentifiers.model_validate({"orb_id": "test-orb-123"})
 
 
 class TestScoreMeasures:
@@ -299,7 +300,7 @@ class TestNetworkDimensions:
         data = {
             "network_type": 1,
         }
-        dimensions = NetworkDimensions(**data)
+        dimensions = NetworkDimensions.model_validate(data)
         assert dimensions.network_type == 1
         assert dimensions.country_code is None
         assert dimensions.city_name is None
@@ -358,7 +359,7 @@ class TestResponsivenessMeasures:
             "packet_loss_pct": 0.0,
             "lag_count": 60,
         }
-        measures = ResponsivenessMeasures(**data)
+        measures = ResponsivenessMeasures.model_validate(data)
         assert measures.lag_avg_us == 25000
         assert measures.router_lag_avg_us is None
         assert measures.router_latency_avg_us is None
@@ -444,7 +445,7 @@ class TestScoreRecord:
             "speed_count": 1,
             "network_type": 1,
         }
-        record = ScoreRecord(**data)
+        record = ScoreRecord.model_validate(data)
         assert record.orb_id == "test-orb-123"
         assert record.orb_name is None
         assert record.device_name is None
@@ -467,7 +468,7 @@ class TestScoreRecord:
         """Test validation error on missing required field."""
         data = {"orb_id": "test-orb-123"}
         with pytest.raises(ValidationError):
-            ScoreRecord(**data)
+            ScoreRecord.model_validate(data)
 
 
 class TestResponsivenessRecord:
@@ -514,7 +515,7 @@ class TestResponsivenessRecord:
             "router_lag_count": 60,
             "network_type": 1,
         }
-        record = ResponsivenessRecord(**data)
+        record = ResponsivenessRecord.model_validate(data)
         assert record.orb_id == "test-orb-123"
         assert record.orb_name is None
         assert record.device_name is None
@@ -564,7 +565,7 @@ class TestWebResponsivenessRecord:
             "dns_us": 50000,
             "network_type": 1,
         }
-        record = WebResponsivenessRecord(**data)
+        record = WebResponsivenessRecord.model_validate(data)
         assert record.orb_id == "test-orb-123"
         assert record.orb_name is None
         assert record.device_name is None
@@ -615,7 +616,7 @@ class TestSpeedRecord:
             "upload_kbps": 10000,
             "network_type": 1,
         }
-        record = SpeedRecord(**data)
+        record = SpeedRecord.model_validate(data)
         assert record.orb_id == "test-orb-123"
         assert record.orb_name is None
         assert record.device_name is None
@@ -696,7 +697,7 @@ class TestWifiLinkMeasures:
             "channel_number": 1,
             "channel_band": "2.4 GHz",
         }
-        measures = WifiLinkMeasures(**data)
+        measures = WifiLinkMeasures.model_validate(data)
         assert measures.rx_rate_mbps is None
         assert measures.security is None
         assert measures.channel_width is None
@@ -723,7 +724,7 @@ class TestWifiLinkMeasures:
             "mcs": 9,
             "nss": 2,
         }
-        measures = WifiLinkMeasures(**data)
+        measures = WifiLinkMeasures.model_validate(data)
         assert measures.mcs == 9
         assert measures.nss == 2
 
@@ -776,7 +777,7 @@ class TestWifiLinkRecord:
             "channel_band": "2.4 GHz",
             "network_type": 1,
         }
-        record = WifiLinkRecord(**data)
+        record = WifiLinkRecord.model_validate(data)
         assert record.orb_id == "test-orb-123"
         assert record.orb_name is None
         assert record.device_name is None
@@ -804,7 +805,7 @@ class TestWifiLinkRecord:
         """Test validation error on missing required field."""
         data = {"orb_id": "test-orb-123"}
         with pytest.raises(ValidationError):
-            WifiLinkRecord(**data)
+            WifiLinkRecord.model_validate(data)
 
 
 class TestAllDatasetsResponse:


### PR DESCRIPTION
## Summary
- Improves `prek.toml`: installs pre-push hooks, switches standard hooks to `repo = "builtin"` (faster, offline), caps large files at 500kb, adds the `debug-statements` hook, and moves `ty` to the pre-push stage with scope broadened to `tests/` and `pyproject.toml` (previously `src/` only).
- Fixes the type errors that broadening `ty` surfaced in `tests/`:
  - `pytest.Mock()` → `MagicMock()` (real bug; `pytest` has no `Mock`)
  - `OrbClientConfig(port=0)` / `(timeout=-1.0)` validation tests now pass required `host=`
  - `Model(**data)` → `Model.model_validate(data)` for heterogeneous-dict fixtures (sidesteps ty's per-kwarg checking; pydantic v2 idiomatic)
  - access pydantic extras via `params.model_extra["..."]` instead of attribute (ty can't see `extra="allow"`)
  - `assert isinstance(text, str)` before `in` checks on FastMCP prompt return values

## Test plan
- [x] `uv run pytest tests/ -q` — 101 passed, 100% coverage
- [x] `prek run --all-files` (pre-commit stage) — all 11 hooks pass
- [x] `prek run --all-files --hook-stage pre-push` — all 12 hooks pass including `ty check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)