### PR TITLE
Modernize MCP server for FastMCP 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Unlike traditional speed tests that provide only momentary snapshots, Orb gives 
 - **Type safety** - Pydantic models for data validation
 - **Multiple granularities** - 1-second, 15-second, and 1-minute data buckets
 - **Polling support** - Automatically fetch only new records
-- **Flexible formats** - JSON or JSONL output
 - **Comprehensive datasets** - Scores, responsiveness, web performance, speed tests, and Wi-Fi link metrics
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ async def main():
 
     if scores:
         latest = scores[-1]
-        print(f"Orb Score: {latest['orb_score']:.0f}")
-        print(f"Responsiveness: {latest['responsiveness_score']:.0f}")
-        print(f"Reliability: {latest['reliability_score']:.0f}")
-        print(f"Speed: {latest['speed_score']:.0f}")
+        print(f"Orb Score: {latest.orb_score:.0f}")
+        print(f"Responsiveness: {latest.responsiveness_score:.0f}")
+        print(f"Reliability: {latest.reliability_score:.0f}")
+        print(f"Speed: {latest.speed_score:.0f}")
 
 asyncio.run(main())
 ```
@@ -113,7 +113,7 @@ async def monitor_network():
     ):
         if records:
             latest = records[-1]
-            latency_ms = latest['latency_avg_us'] / 1000
+            latency_ms = latest.latency_avg_us / 1000
             print(f"Latency: {latency_ms:.1f}ms")
 ```
 
@@ -123,12 +123,12 @@ async def monitor_network():
 def alert_callback(dataset_name, records):
     for record in records:
         # Alert on high latency
-        if record['latency_avg_us'] > 50000:  # 50ms
-            print(f"⚠️  High latency: {record['latency_avg_us']}μs")
+        if record.latency_avg_us > 50000:  # 50ms
+            print(f"⚠️  High latency: {record.latency_avg_us}μs")
 
         # Alert on packet loss
-        if record['packet_loss_pct'] > 1.0:  # 1%
-            print(f"⚠️  Packet loss: {record['packet_loss_pct']:.2f}%")
+        if record.packet_loss_pct > 1.0:  # 1%
+            print(f"⚠️  Packet loss: {record.packet_loss_pct:.2f}%")
 
 async def monitor_with_alerts():
     client = OrbAPIClient(host="192.168.0.20")
@@ -149,7 +149,7 @@ async def analyze_speeds():
     speeds = await client.get_speed_results()
 
     # Convert to Mbps and calculate statistics
-    downloads = [s['download_kbps'] / 1000 for s in speeds]
+    downloads = [s.download_kbps / 1000 for s in speeds]
 
     avg_speed = sum(downloads) / len(downloads)
     min_speed = min(downloads)
@@ -179,10 +179,10 @@ async def compare_by_isp():
     # Group scores by ISP
     isp_scores = {}
     for record in scores:
-        isp = record['isp_name']
+        isp = record.isp_name
         if isp not in isp_scores:
             isp_scores[isp] = []
-        isp_scores[isp].append(record['orb_score'])
+        isp_scores[isp].append(record.orb_score)
 
     # Calculate averages
     for isp, scores_list in isp_scores.items():
@@ -309,25 +309,25 @@ client = OrbAPIClient(
 
 #### Methods
 
-- **`get_scores_1m(format="json", caller_id=None)`**
+- **`get_scores_1m(caller_id=None)`**
   Retrieve 1-minute granularity Scores dataset
 
-- **`get_responsiveness(granularity="1m", format="json", caller_id=None)`**
+- **`get_responsiveness(granularity="1m", caller_id=None)`**
   Retrieve Responsiveness dataset (1s, 15s, or 1m)
 
-- **`get_web_responsiveness(format="json", caller_id=None)`**
+- **`get_web_responsiveness(caller_id=None)`**
   Retrieve Web Responsiveness dataset
 
-- **`get_speed_results(format="json", caller_id=None)`**
+- **`get_speed_results(caller_id=None)`**
   Retrieve Speed test results
 
 - **`get_wifi_link(granularity="1m", caller_id=None)`**
   Retrieve Wi-Fi Link dataset (1s, 15s, or 1m)
 
-- **`get_all_datasets(format="json", caller_id=None, include_all_responsiveness=False)`**
+- **`get_all_datasets(caller_id=None, include_all_responsiveness=False, include_all_wifi_link=False, default_granularity="1m")`**
   Retrieve all datasets concurrently
 
-- **`poll_dataset(dataset_name, interval=60.0, format="json", callback=None, max_iterations=None)`**
+- **`poll_dataset(dataset_name, interval=60.0, callback=None, max_iterations=None)`**
   Continuously poll a dataset at regular intervals
 
 #### Properties
@@ -337,32 +337,6 @@ client = OrbAPIClient(
 - `caller_id` - Configured caller ID
 - `client_id` - Configured client ID
 - `timeout` - Request timeout
-
-## Output Formats
-
-### JSON (default)
-
-Returns a Python list of dictionaries:
-
-```python
-scores = await client.get_scores_1m(format="json")
-# Returns: [{"orb_score": 85.5, ...}, {"orb_score": 87.2, ...}]
-```
-
-### JSONL (JSON Lines)
-
-Returns newline-delimited JSON as a string, useful for streaming:
-
-```python
-scores = await client.get_scores_1m(format="jsonl")
-# Returns: '{"orb_score": 85.5, ...}\n{"orb_score": 87.2, ...}\n'
-
-# Parse it:
-import json
-for line in scores.strip().split('\n'):
-    record = json.loads(line)
-    print(record['orb_score'])
-```
 
 ## Error Handling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ orbnet-mcp = "orbnet.mcp_server:main"
 [project.optional-dependencies]
 mcp = [
     "fastmcp>=3.2.0",
+    "mcp>=1.0.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pytest>=8.4.2",
     "pytest-asyncio>=0.23.0",
     "pytest-mock>=3.12.0",
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
     "pytest-cov>=7.0.0",
     "prek>=0.3.8",
     "ty>=0.0.29",
@@ -44,7 +44,7 @@ orbnet-mcp = "orbnet.mcp_server:main"
 
 [project.optional-dependencies]
 mcp = [
-    "fastmcp>=2.12.4",
+    "fastmcp>=3.2.0",
 ]
 
 [build-system]

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -17,9 +17,10 @@ Stateful Polling:
 
 import os
 import uuid
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal
 
 from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from .client import OrbAPIClient
@@ -122,10 +123,10 @@ config = OrbSensorConfig.from_env()
 
 
 def get_client(
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
+    host: str | None = None,
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
 ) -> OrbAPIClient:
     """Create an OrbAPIClient with config defaults and optional overrides."""
     return OrbAPIClient(
@@ -137,20 +138,17 @@ def get_client(
 
 
 @mcp.tool(
-    annotations={
-        "title": "Get Scores Dataset (1m)",
-        "readOnlyHint": True,
-        "idempotentHint": False,
-        "openWorldHint": True,
-    }
+    title="Get Scores Dataset (1m)",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    tags={"orb", "scores"},
 )
 async def get_scores_1m(
     ctx: Context,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
-) -> List[ScoreRecord]:
+    host: str | None = None,
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
+) -> list[ScoreRecord]:
     """
     Retrieve 1-minute granularity Scores dataset from an Orb sensor.
 
@@ -229,21 +227,18 @@ async def get_scores_1m(
 
 
 @mcp.tool(
-    annotations={
-        "title": "Get Responsiveness Dataset",
-        "readOnlyHint": True,
-        "idempotentHint": False,
-        "openWorldHint": True,
-    }
+    title="Get Responsiveness Dataset",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    tags={"orb", "responsiveness"},
 )
 async def get_responsiveness(
     ctx: Context,
-    host: Optional[str] = None,
+    host: str | None = None,
     granularity: Literal["1s", "15s", "1m"] = "1s",
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
-) -> List[ResponsivenessRecord]:
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
+) -> list[ResponsivenessRecord]:
     """
     Retrieve Responsiveness dataset from an Orb sensor at a single granularity.
 
@@ -308,20 +303,17 @@ async def get_responsiveness(
 
 
 @mcp.tool(
-    annotations={
-        "title": "Get Web Responsiveness Dataset",
-        "readOnlyHint": True,
-        "idempotentHint": False,
-        "openWorldHint": True,
-    }
+    title="Get Web Responsiveness Dataset",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    tags={"orb", "web-performance"},
 )
 async def get_web_responsiveness(
     ctx: Context,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
-) -> List[WebResponsivenessRecord]:
+    host: str | None = None,
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
+) -> list[WebResponsivenessRecord]:
     """
     Retrieve Web Responsiveness dataset from an Orb sensor.
 
@@ -356,20 +348,17 @@ async def get_web_responsiveness(
 
 
 @mcp.tool(
-    annotations={
-        "title": "Get Speed Test Results",
-        "readOnlyHint": True,
-        "idempotentHint": False,
-        "openWorldHint": True,
-    }
+    title="Get Speed Test Results",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    tags={"orb", "speed"},
 )
 async def get_speed_results(
     ctx: Context,
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
-) -> List[SpeedRecord]:
+    host: str | None = None,
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
+) -> list[SpeedRecord]:
     """
     Retrieve Speed test results dataset from an Orb sensor.
 
@@ -404,21 +393,18 @@ async def get_speed_results(
 
 
 @mcp.tool(
-    annotations={
-        "title": "Get Wi-Fi Link Dataset",
-        "readOnlyHint": True,
-        "idempotentHint": False,
-        "openWorldHint": True,
-    }
+    title="Get Wi-Fi Link Dataset",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    tags={"orb", "wifi"},
 )
 async def get_wifi_link(
     ctx: Context,
-    host: Optional[str] = None,
+    host: str | None = None,
     granularity: Literal["1s", "15s", "1m"] = "1s",
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
-) -> List[WifiLinkRecord]:
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
+) -> list[WifiLinkRecord]:
     """
     Retrieve Wi-Fi Link dataset from an Orb sensor at a single granularity.
 
@@ -480,21 +466,18 @@ async def get_wifi_link(
 
 
 @mcp.tool(
-    annotations={
-        "title": "Get All Datasets",
-        "readOnlyHint": True,
-        "idempotentHint": False,
-        "openWorldHint": True,
-    }
+    title="Get All Datasets",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    tags={"orb", "aggregate"},
 )
 async def get_all_datasets(
     ctx: Context,
-    host: Optional[str] = None,
+    host: str | None = None,
     include_all_responsiveness: bool = False,
     include_all_wifi_link: bool = False,
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
 ) -> AllDatasetsResponse:
     """
     Retrieve all available datasets from an Orb sensor concurrently.
@@ -562,11 +545,11 @@ async def get_all_datasets(
 
 
 def _get_client_info_impl(
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
-) -> Dict[str, Any]:
+    host: str | None = None,
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
     """
     Get information about the Orb API client configuration.
 
@@ -600,24 +583,21 @@ def _get_client_info_impl(
 
 
 @mcp.tool(
-    annotations={
-        "title": "Get Client Configuration",
-        "readOnlyHint": True,
-        "idempotentHint": True,
-        "openWorldHint": False,
-    }
+    title="Get Client Configuration",
+    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
+    tags={"orb", "config"},
 )
 def get_client_info(
-    host: Optional[str] = None,
-    port: Optional[int] = None,
-    caller_id: Optional[str] = None,
-    timeout: Optional[float] = None,
-) -> Dict[str, Any]:
+    host: str | None = None,
+    port: int | None = None,
+    caller_id: str | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
     """Get information about the Orb API client configuration."""
     return _get_client_info_impl(host, port, caller_id, timeout)
 
 
-@mcp.prompt()
+@mcp.prompt(title="Analyze Network Quality", tags={"orb", "analysis"})
 def analyze_network_quality() -> str:
     """Analyze current network quality for the configured Orb and provide insights"""
     return """
@@ -630,7 +610,9 @@ def analyze_network_quality() -> str:
     """
 
 
-@mcp.prompt()
+@mcp.prompt(
+    title="Troubleshoot Slow Internet", tags={"orb", "speed", "troubleshooting"}
+)
 def troubleshoot_slow_internet() -> str:
     """Diagnose slow internet connection issues"""
     return """
@@ -646,7 +628,7 @@ def troubleshoot_slow_internet() -> str:
     """
 
 
-@mcp.prompt()
+@mcp.prompt(title="Troubleshoot Wi-Fi", tags={"orb", "wifi", "troubleshooting"})
 def troubleshoot_wifi() -> str:
     """Diagnose Wi-Fi-specific issues by correlating signal metrics with performance"""
     return """

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -120,8 +120,10 @@ def test_main_invokes_mcp_run(mocker):
 
 async def test_tool_metadata_get_scores_1m():
     tool = await mcp_server.mcp.get_tool("get_scores_1m")
+    assert tool is not None
     assert tool.title == "Get Scores Dataset (1m)"
     assert tool.tags == {"orb", "scores"}
+    assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
     assert tool.annotations.openWorldHint is True
     assert tool.annotations.idempotentHint is None
@@ -129,8 +131,10 @@ async def test_tool_metadata_get_scores_1m():
 
 async def test_tool_metadata_get_responsiveness():
     tool = await mcp_server.mcp.get_tool("get_responsiveness")
+    assert tool is not None
     assert tool.title == "Get Responsiveness Dataset"
     assert tool.tags == {"orb", "responsiveness"}
+    assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
     assert tool.annotations.openWorldHint is True
     assert tool.annotations.idempotentHint is None
@@ -138,8 +142,10 @@ async def test_tool_metadata_get_responsiveness():
 
 async def test_tool_metadata_get_web_responsiveness():
     tool = await mcp_server.mcp.get_tool("get_web_responsiveness")
+    assert tool is not None
     assert tool.title == "Get Web Responsiveness Dataset"
     assert tool.tags == {"orb", "web-performance"}
+    assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
     assert tool.annotations.openWorldHint is True
     assert tool.annotations.idempotentHint is None
@@ -147,8 +153,10 @@ async def test_tool_metadata_get_web_responsiveness():
 
 async def test_tool_metadata_get_speed_results():
     tool = await mcp_server.mcp.get_tool("get_speed_results")
+    assert tool is not None
     assert tool.title == "Get Speed Test Results"
     assert tool.tags == {"orb", "speed"}
+    assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
     assert tool.annotations.openWorldHint is True
     assert tool.annotations.idempotentHint is None
@@ -156,8 +164,10 @@ async def test_tool_metadata_get_speed_results():
 
 async def test_tool_metadata_get_wifi_link():
     tool = await mcp_server.mcp.get_tool("get_wifi_link")
+    assert tool is not None
     assert tool.title == "Get Wi-Fi Link Dataset"
     assert tool.tags == {"orb", "wifi"}
+    assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
     assert tool.annotations.openWorldHint is True
     assert tool.annotations.idempotentHint is None
@@ -165,8 +175,10 @@ async def test_tool_metadata_get_wifi_link():
 
 async def test_tool_metadata_get_all_datasets():
     tool = await mcp_server.mcp.get_tool("get_all_datasets")
+    assert tool is not None
     assert tool.title == "Get All Datasets"
     assert tool.tags == {"orb", "aggregate"}
+    assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
     assert tool.annotations.openWorldHint is True
     assert tool.annotations.idempotentHint is None
@@ -174,8 +186,10 @@ async def test_tool_metadata_get_all_datasets():
 
 async def test_tool_metadata_get_client_info():
     tool = await mcp_server.mcp.get_tool("get_client_info")
+    assert tool is not None
     assert tool.title == "Get Client Configuration"
     assert tool.tags == {"orb", "config"}
+    assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
     assert tool.annotations.openWorldHint is False
     assert tool.annotations.idempotentHint is None
@@ -188,18 +202,21 @@ async def test_tool_metadata_get_client_info():
 
 async def test_prompt_metadata_analyze_network_quality():
     prompt = await mcp_server.mcp.get_prompt("analyze_network_quality")
+    assert prompt is not None
     assert prompt.title == "Analyze Network Quality"
     assert prompt.tags == {"orb", "analysis"}
 
 
 async def test_prompt_metadata_troubleshoot_slow_internet():
     prompt = await mcp_server.mcp.get_prompt("troubleshoot_slow_internet")
+    assert prompt is not None
     assert prompt.title == "Troubleshoot Slow Internet"
     assert prompt.tags == {"orb", "speed", "troubleshooting"}
 
 
 async def test_prompt_metadata_troubleshoot_wifi():
     prompt = await mcp_server.mcp.get_prompt("troubleshoot_wifi")
+    assert prompt is not None
     assert prompt.title == "Troubleshoot Wi-Fi"
     assert prompt.tags == {"orb", "wifi", "troubleshooting"}
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -110,3 +110,94 @@ def test_main_invokes_mcp_run(mocker):
     run = mocker.patch.object(mcp_server.mcp, "run")
     mcp_server.main()
     run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tool metadata tests (FastMCP 3.2: title, tags, ToolAnnotations)
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_metadata_get_scores_1m():
+    tool = await mcp_server.mcp.get_tool("get_scores_1m")
+    assert tool.title == "Get Scores Dataset (1m)"
+    assert tool.tags == {"orb", "scores"}
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.openWorldHint is True
+    assert tool.annotations.idempotentHint is None
+
+
+async def test_tool_metadata_get_responsiveness():
+    tool = await mcp_server.mcp.get_tool("get_responsiveness")
+    assert tool.title == "Get Responsiveness Dataset"
+    assert tool.tags == {"orb", "responsiveness"}
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.openWorldHint is True
+    assert tool.annotations.idempotentHint is None
+
+
+async def test_tool_metadata_get_web_responsiveness():
+    tool = await mcp_server.mcp.get_tool("get_web_responsiveness")
+    assert tool.title == "Get Web Responsiveness Dataset"
+    assert tool.tags == {"orb", "web-performance"}
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.openWorldHint is True
+    assert tool.annotations.idempotentHint is None
+
+
+async def test_tool_metadata_get_speed_results():
+    tool = await mcp_server.mcp.get_tool("get_speed_results")
+    assert tool.title == "Get Speed Test Results"
+    assert tool.tags == {"orb", "speed"}
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.openWorldHint is True
+    assert tool.annotations.idempotentHint is None
+
+
+async def test_tool_metadata_get_wifi_link():
+    tool = await mcp_server.mcp.get_tool("get_wifi_link")
+    assert tool.title == "Get Wi-Fi Link Dataset"
+    assert tool.tags == {"orb", "wifi"}
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.openWorldHint is True
+    assert tool.annotations.idempotentHint is None
+
+
+async def test_tool_metadata_get_all_datasets():
+    tool = await mcp_server.mcp.get_tool("get_all_datasets")
+    assert tool.title == "Get All Datasets"
+    assert tool.tags == {"orb", "aggregate"}
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.openWorldHint is True
+    assert tool.annotations.idempotentHint is None
+
+
+async def test_tool_metadata_get_client_info():
+    tool = await mcp_server.mcp.get_tool("get_client_info")
+    assert tool.title == "Get Client Configuration"
+    assert tool.tags == {"orb", "config"}
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.openWorldHint is False
+    assert tool.annotations.idempotentHint is None
+
+
+# ---------------------------------------------------------------------------
+# Prompt metadata tests (FastMCP 3.2: title, tags)
+# ---------------------------------------------------------------------------
+
+
+async def test_prompt_metadata_analyze_network_quality():
+    prompt = await mcp_server.mcp.get_prompt("analyze_network_quality")
+    assert prompt.title == "Analyze Network Quality"
+    assert prompt.tags == {"orb", "analysis"}
+
+
+async def test_prompt_metadata_troubleshoot_slow_internet():
+    prompt = await mcp_server.mcp.get_prompt("troubleshoot_slow_internet")
+    assert prompt.title == "Troubleshoot Slow Internet"
+    assert prompt.tags == {"orb", "speed", "troubleshooting"}
+
+
+async def test_prompt_metadata_troubleshoot_wifi():
+    prompt = await mcp_server.mcp.get_prompt("troubleshoot_wifi")
+    assert prompt.title == "Troubleshoot Wi-Fi"
+    assert prompt.tags == {"orb", "wifi", "troubleshooting"}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -221,6 +221,25 @@ async def test_prompt_metadata_troubleshoot_wifi():
     assert prompt.tags == {"orb", "wifi", "troubleshooting"}
 
 
+async def test_registered_tools_and_prompts():
+    tools = await mcp_server.mcp.list_tools()
+    prompts = await mcp_server.mcp.list_prompts()
+    assert {t.name for t in tools} == {
+        "get_scores_1m",
+        "get_responsiveness",
+        "get_web_responsiveness",
+        "get_speed_results",
+        "get_wifi_link",
+        "get_all_datasets",
+        "get_client_info",
+    }
+    assert {p.name for p in prompts} == {
+        "analyze_network_quality",
+        "troubleshoot_slow_internet",
+        "troubleshoot_wifi",
+    }
+
+
 async def test_get_all_datasets_error_payload_passthrough(mock_client, ctx):
     error_payload = ErrorPayload(error="connection refused")
     response = AllDatasetsResponse(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from orbnet import mcp_server
+from orbnet.models import AllDatasetsResponse, ErrorPayload
 
 
 @pytest.fixture
@@ -201,3 +202,26 @@ async def test_prompt_metadata_troubleshoot_wifi():
     prompt = await mcp_server.mcp.get_prompt("troubleshoot_wifi")
     assert prompt.title == "Troubleshoot Wi-Fi"
     assert prompt.tags == {"orb", "wifi", "troubleshooting"}
+
+
+async def test_get_all_datasets_error_payload_passthrough(mock_client, ctx):
+    error_payload = ErrorPayload(error="connection refused")
+    response = AllDatasetsResponse(
+        scores_1m=[],
+        responsiveness_1s=error_payload,
+        web_responsiveness=[],
+        speed_results=[],
+    )
+    mock_client.get_all_datasets = AsyncMock(return_value=response)
+
+    result = await mcp_server.get_all_datasets(ctx, host="h")
+
+    assert isinstance(result, AllDatasetsResponse)
+    dumped = result.model_dump()
+    assert dumped["responsiveness_1s"] == {"error": "connection refused"}
+    assert dumped["scores_1m"] == []
+    mock_client.get_all_datasets.assert_awaited_once_with(
+        include_all_responsiveness=False,
+        include_all_wifi_link=False,
+        default_granularity="1s",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -699,7 +699,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.12.4" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.11.9" },
 ]
@@ -707,7 +707,7 @@ provides-extras = ["mcp"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "fastmcp", specifier = ">=2.12.4" },
+    { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "prek", specifier = ">=0.3.8" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -684,6 +684,7 @@ dependencies = [
 [package.optional-dependencies]
 mcp = [
     { name = "fastmcp" },
+    { name = "mcp" },
 ]
 
 [package.dev-dependencies]
@@ -701,6 +702,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
 ]
 provides-extras = ["mcp"]


### PR DESCRIPTION
## Summary

- Bumps FastMCP minimum to `>=3.2.0` (drops 2.x support) in both `[dependency-groups].dev` and `[project.optional-dependencies].mcp`
- Replaces dict-based tool annotations with typed `mcp.types.ToolAnnotations` and first-class `title=` / `tags=` parameters on all 7 tools and 3 prompts; drops `idempotentHint` from all read-only tools (per MCP spec it is only meaningful when `readOnlyHint=False`)
- Updates all function signatures from legacy `Optional[X]` / `List[X]` / `Dict[K,V]` to Python 3.10+ `X | None` / `list[X]` / `dict[K,V]` syntax
- Adds granular tags per tool/prompt (`"orb"` domain tag + dataset-specific tag)
- Adds 10 metadata tests verifying title, tags, and ToolAnnotations registration; adds 1 regression test verifying `AllDatasetsResponse` error payload passthrough

## Test Plan

- [x] 152 tests pass, 100% coverage
- [x] Pre-push gate clean: ruff check, ruff format, ty check all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)