### PR TITLE
fix(mcp): align granularity defaults with client

### DIFF
--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -246,7 +246,7 @@ async def get_scores_1m(
 async def get_responsiveness(
     ctx: Context,
     host: str | None = None,
-    granularity: Granularity = "1s",
+    granularity: Granularity = "1m",
     port: int | None = None,
     caller_id: str | None = None,
     timeout: float | None = None,
@@ -271,7 +271,7 @@ async def get_responsiveness(
         for updates without receiving duplicate records.
 
     Args:
-        granularity: Time bucket size - '1s', '15s', or '1m' (default: '1s')
+        granularity: Time bucket size - '1s', '15s', or '1m' (default: '1m')
         host: Orb sensor hostname or IP (default: from ORB_HOST env var or 'localhost')
         port: API port number (default: from ORB_PORT env var or 7080)
         caller_id: Unique ID to track polling state. Leave as None to use the default
@@ -412,7 +412,7 @@ async def get_speed_results(
 async def get_wifi_link(
     ctx: Context,
     host: str | None = None,
-    granularity: Granularity = "1s",
+    granularity: Granularity = "1m",
     port: int | None = None,
     caller_id: str | None = None,
     timeout: float | None = None,
@@ -442,7 +442,7 @@ async def get_wifi_link(
         for updates without receiving duplicate records.
 
     Args:
-        granularity: Time bucket size - '1s', '15s', or '1m' (default: '1s')
+        granularity: Time bucket size - '1s', '15s', or '1m' (default: '1m')
         host: Orb sensor hostname or IP (default: from ORB_HOST env var or 'localhost')
         port: API port number (default: from ORB_PORT env var or 7080)
         caller_id: Unique ID to track polling state. Leave as None to use the default
@@ -505,10 +505,10 @@ async def get_all_datasets(
 
     Args:
         include_all_responsiveness: If True, fetches all responsiveness granularities
-                                   (1s, 15s, 1m). If False, only fetches 1s. (default:
+                                   (1s, 15s, 1m). If False, only fetches 1m. (default:
                                    False)
         include_all_wifi_link: If True, fetches all Wi-Fi Link granularities
-                               (1s, 15s, 1m). If False, only fetches 1s. (default:
+                               (1s, 15s, 1m). If False, only fetches 1m. (default:
                                False)
         host: Orb sensor hostname or IP (default: from ORB_HOST env var or 'localhost')
         port: API port number (default: from ORB_PORT env var or 7080)
@@ -519,25 +519,28 @@ async def get_all_datasets(
     Returns:
         AllDatasetsResponse object with fields for each dataset type:
         - scores_1m: 1-minute scores dataset
-        - responsiveness_1s: 1-second responsiveness dataset
-        - responsiveness_15s: 15-second responsiveness
+        - responsiveness_1m: 1-minute responsiveness dataset
+        - responsiveness_1s: 1-second responsiveness
           (if include_all_responsiveness=True)
-        - responsiveness_1m: 1-minute responsiveness
+        - responsiveness_15s: 15-second responsiveness
           (if include_all_responsiveness=True)
         - web_responsiveness: Web responsiveness results
         - speed_results: Speed test results
-        - wifi_link_1s: 1-second Wi-Fi link dataset (empty list if not on Wi-Fi)
+        - wifi_link_1m: 1-minute Wi-Fi link dataset (empty list if not on Wi-Fi)
+        - wifi_link_1s: 1-second Wi-Fi link (if include_all_wifi_link=True)
         - wifi_link_15s: 15-second Wi-Fi link (if include_all_wifi_link=True)
-        - wifi_link_1m: 1-minute Wi-Fi link (if include_all_wifi_link=True)
 
         Each field is either a list of records or an ErrorPayload (typed
         `{"error": "..."}` payload) if that dataset failed to fetch.
 
-        For Python consumers, branch with is_ok() / .error:
+        For Python consumers, call OrbAPIClient directly (the MCP tool
+        function takes a FastMCP-injected ctx) and branch with is_ok() / .error:
 
-        >>> from orbnet.models import is_ok, unwrap
-        >>> result = await get_all_datasets()
-        >>> for field_name in ("scores_1m", "responsiveness_1s", "speed_results"):
+        >>> from orbnet import OrbAPIClient
+        >>> from orbnet.models import is_ok
+        >>> client = OrbAPIClient(host="192.168.1.100")
+        >>> result = await client.get_all_datasets()
+        >>> for field_name in ("scores_1m", "responsiveness_1m", "speed_results"):
         ...     value = getattr(result, field_name)
         ...     if is_ok(value):
         ...         print(f"{field_name}: {len(value)} records")
@@ -552,7 +555,7 @@ async def get_all_datasets(
     return await client.get_all_datasets(
         include_all_responsiveness=include_all_responsiveness,
         include_all_wifi_link=include_all_wifi_link,
-        default_granularity="1s",
+        default_granularity="1m",
     )
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,11 +4,13 @@ These tests invoke FastMCP-decorated tools and prompts directly, patching
 ``get_client`` so no real network calls are made.
 """
 
+import inspect
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from orbnet import mcp_server
+from orbnet.client import OrbAPIClient
 from orbnet.models import AllDatasetsResponse, ErrorPayload
 
 
@@ -73,7 +75,7 @@ async def test_get_all_datasets_tool(mock_client, ctx):
     mock_client.get_all_datasets.assert_awaited_once_with(
         include_all_responsiveness=True,
         include_all_wifi_link=True,
-        default_granularity="1s",
+        default_granularity="1m",
     )
 
 
@@ -111,6 +113,63 @@ def test_main_invokes_mcp_run(mocker):
     run = mocker.patch.object(mcp_server.mcp, "run")
     mcp_server.main()
     run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Default-parity tests: MCP tool defaults must agree with client defaults.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mcp_tool", "client_method"),
+    [
+        (mcp_server.get_responsiveness, OrbAPIClient.get_responsiveness),
+        (mcp_server.get_wifi_link, OrbAPIClient.get_wifi_link),
+    ],
+)
+def test_mcp_tool_granularity_default_matches_client(mcp_tool, client_method):
+    mcp_default = inspect.signature(mcp_tool).parameters["granularity"].default
+    client_default = inspect.signature(client_method).parameters["granularity"].default
+    assert mcp_default == client_default, (
+        f"{mcp_tool.__name__}(granularity=) defaults to {mcp_default!r} but "
+        f"{client_method.__qualname__}(granularity=) defaults to {client_default!r}; "
+        "MCP tool defaults must match the client to avoid silent behavior drift."
+    )
+
+
+async def test_get_all_datasets_forwards_client_default_granularity(mock_client, ctx):
+    """get_all_datasets does not currently expose default_granularity to MCP callers,
+    so it must forward whatever the underlying client treats as default. This locks
+    the MCP-layer hardcode to track the client default if either side moves.
+    """
+    await mcp_server.get_all_datasets(ctx, host="h")
+    call_kwargs = mock_client.get_all_datasets.await_args.kwargs
+    client_default = (
+        inspect.signature(OrbAPIClient.get_all_datasets)
+        .parameters["default_granularity"]
+        .default
+    )
+    assert call_kwargs["default_granularity"] == client_default
+
+
+@pytest.mark.parametrize(
+    ("mcp_tool", "client_method_attr"),
+    [
+        (mcp_server.get_responsiveness, "get_responsiveness"),
+        (mcp_server.get_wifi_link, "get_wifi_link"),
+    ],
+)
+async def test_mcp_tool_no_arg_forwards_client_default_granularity(
+    mock_client, ctx, mcp_tool, client_method_attr
+):
+    """No-arg MCP call must forward the client's default granularity."""
+    await mcp_tool(ctx, host="h")
+    client_method = getattr(OrbAPIClient, client_method_attr)
+    client_default = inspect.signature(client_method).parameters["granularity"].default
+    forwarded = getattr(mock_client, client_method_attr).await_args.kwargs[
+        "granularity"
+    ]
+    assert forwarded == client_default
 
 
 # ---------------------------------------------------------------------------
@@ -259,7 +318,7 @@ async def test_get_all_datasets_error_payload_passthrough(mock_client, ctx):
     mock_client.get_all_datasets.assert_awaited_once_with(
         include_all_responsiveness=False,
         include_all_wifi_link=False,
-        default_granularity="1s",
+        default_granularity="1m",
     )
 
 


### PR DESCRIPTION
## Summary
- The MCP tools `get_responsiveness`, `get_wifi_link`, and `get_all_datasets` defaulted `granularity` to `"1s"` while `OrbAPIClient` and the request models defaulted to `"1m"`. Same API, different behavior depending on entry point — calling a tool without `granularity` returned 1-second data via MCP but 1-minute data via direct client use.
- Aligns the MCP layer to `"1m"`: matches the client's existing default, lower data volume, and more likely to be enabled on a given sensor.
- Adds parity regression tests via `inspect.signature` plus runtime no-arg forwarding tests so future drift between the two layers fails CI.

This is PR 1 of a small follow-up series from an agent-friendliness audit of the MCP server. Bug spotted by an independent Codex review pass.

## Test plan
- [x] `uv run pytest tests/ -q` — 158 pass, 100% coverage
- [x] `uv run prek run --all-files --hook-stage pre-push` — ruff + ty clean
- [x] Independent Codex review on the diff
- [ ] Manual smoke through an MCP client: confirm `get_responsiveness()` with no granularity arg returns 1-minute data