### PR TITLE
chore(mcp): tighten server discoverability and annotation honesty

### DIFF
--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -24,6 +24,7 @@ from fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
+from . import __version__
 from .client import OrbAPIClient
 from .models import (
     AllDatasetsResponse,
@@ -35,11 +36,23 @@ from .models import (
     WifiLinkRecord,
 )
 
+SERVER_FINGERPRINT = f"orbnet@{__version__}"
+
 # Initialize FastMCP server
 mcp = FastMCP(
     "Orb Network Quality Data",
-    instructions="""
+    instructions=f"""
     This server provides real-time network quality monitoring from Orb sensors.
+
+    **Server fingerprint:** {SERVER_FINGERPRINT}
+    **Transport:** stdio
+    **Auth:** None — sensor must be reachable on the local network with Local API enabled
+    **Ambient state:** Reads ORB_HOST, ORB_PORT, ORB_TIMEOUT env vars (cached
+    after first tool call). Polling state is keyed by a session-specific
+    caller_id: the Orb sensor uses that id to track which records each caller
+    has already seen and returns only new ones on subsequent calls. Because
+    the polling state lives on the sensor (not this MCP server), per-tool
+    readOnlyHint=True remains accurate.
 
     **What You Can Ask:**
     ✓ "What's my current network quality?"
@@ -62,6 +75,13 @@ mcp = FastMCP(
     - Historical data depends on sensor configuration
     - Wi-Fi Link data not available on iOS or ethernet-connected sensors
     - Not all granularities may be enabled on a given Orb sensor
+
+    **Does NOT:**
+    - Provide historical data beyond what the sensor retains
+    - Control or configure the sensor (start, stop, change settings)
+    - Aggregate across multiple sensors in a single call
+    - Provide alerts, notifications, or push updates
+    - Necessarily reflect the user's local network (the sensor may be elsewhere)
 
     **IMPORTANT — Granularity Fallback:**
     The responsiveness and Wi-Fi link datasets support multiple granularities
@@ -586,6 +606,7 @@ def _get_client_info_impl(
         - base_url: Full base URL for API requests
         - caller_id: Caller ID being used for polling state tracking
         - timeout: Request timeout in seconds
+        - server_fingerprint: Versioned MCP server identity (e.g. "orbnet@0.4.0")
     """
     client = get_client(host, port, caller_id, timeout)
     return {
@@ -594,6 +615,7 @@ def _get_client_info_impl(
         "base_url": client.base_url,
         "caller_id": client.caller_id,
         "timeout": client.timeout,
+        "server_fingerprint": SERVER_FINGERPRINT,
     }
 
 
@@ -616,6 +638,8 @@ def get_client_info(
 def analyze_network_quality() -> str:
     """Analyze current network quality for the configured Orb and provide insights"""
     return """
+    **Prerequisites:** Orb sensor reachable on the network with Local API enabled.
+
     Analyze the network quality using these steps:
     1. Call get_scores_1m() to get the latest Orb scores
     2. Examine orb_score (0-100, higher is better)
@@ -631,6 +655,8 @@ def analyze_network_quality() -> str:
 def troubleshoot_slow_internet() -> str:
     """Diagnose slow internet connection issues"""
     return """
+    **Prerequisites:** Orb sensor reachable on the network with Local API enabled.
+
     To troubleshoot slow internet:
     1. Call get_speed_results() to check recent speed tests
     2. Call get_responsiveness() for latency/jitter data
@@ -647,6 +673,9 @@ def troubleshoot_slow_internet() -> str:
 def troubleshoot_wifi() -> str:
     """Diagnose Wi-Fi-specific issues by correlating signal metrics with performance"""
     return """
+    **Prerequisites:** Orb sensor connected via Wi-Fi with Local API enabled.
+    Wi-Fi Link data is unavailable on iOS or ethernet-connected sensors.
+
     To diagnose Wi-Fi-specific network issues:
     1. Call get_wifi_link() to get signal and link metrics
     2. Examine key signal indicators:
@@ -668,10 +697,9 @@ def troubleshoot_wifi() -> str:
        - Low SNR + packet loss = RF interference (neighboring networks, appliances)
        - Low link rate + low speed = signal quality is bottlenecking bandwidth
        - Good signal but slow speed = likely a WAN or ISP issue, not Wi-Fi
-    7. Note: Wi-Fi Link data is not available on iOS or ethernet-connected Orbs.
-       Some fields are platform-specific (rx_rate_mbps unavailable on macOS;
-       security and channel_width unavailable on Android; mcs and nss Linux only).
-    8. Summarize with specific, actionable recommendations.
+    7. Summarize with specific, actionable recommendations.
+       (Field-availability quirks across platforms are documented on
+       WifiLinkRecord — read the response to see what's present.)
     """
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -390,3 +390,99 @@ class TestLazyConfigLoading:
         first = mcp_server.get_config()
         second = mcp_server.get_config()
         assert first is second
+
+
+# ---------------------------------------------------------------------------
+# Discoverability surface (PR 2 — F4/F7/F8/F9):
+#   - Server instructions declare transport, auth, ambient state, fingerprint,
+#     and explicit negative scope.
+#   - get_client_info exposes a server fingerprint.
+#   - Prompts list prerequisites and avoid duplicating model-level platform
+#     notes.
+# ---------------------------------------------------------------------------
+
+
+class TestServerInstructions:
+    """The instructions block is what an MCP client reads at cold start —
+    transport, auth, ambient state, negative scope, and the capability
+    fingerprint must all be discoverable from this single text.
+    """
+
+    @pytest.fixture
+    def text(self):
+        return mcp_server.mcp.instructions or ""
+
+    @pytest.mark.parametrize(
+        "anchor",
+        [
+            "Transport:",
+            "Auth:",
+            "Ambient state:",
+            "Server fingerprint:",
+            "Does NOT",
+        ],
+    )
+    def test_declares_section(self, text, anchor):
+        assert anchor in text, f"server instructions should declare '{anchor}'"
+
+    def test_fingerprint_includes_version(self, text):
+        from orbnet import __version__
+
+        assert f"orbnet@{__version__}" in text
+
+    @pytest.mark.parametrize("env_var", ["ORB_HOST", "ORB_PORT", "ORB_TIMEOUT"])
+    def test_lists_ambient_env_vars(self, text, env_var):
+        assert env_var in text
+
+
+class TestGetClientInfoFingerprint:
+    """get_client_info should surface the server fingerprint so agents that
+    skip the instructions block can still discover the version they're against.
+    """
+
+    def test_response_includes_server_fingerprint(self, mock_client):
+        from orbnet import __version__
+
+        mock_client.host = "h"
+        mock_client.port = 7080
+        mock_client.base_url = "http://h:7080"
+        mock_client.caller_id = "cid"
+        mock_client.timeout = 30.0
+
+        info = mcp_server.get_client_info(host="h")
+
+        assert info["server_fingerprint"] == f"orbnet@{__version__}"
+
+
+class TestPromptPrerequisites:
+    """Each prompt should declare its prerequisites so agents can fail fast
+    with a clear message instead of mid-execution.
+    """
+
+    @pytest.mark.parametrize(
+        "prompt_fn",
+        [
+            mcp_server.analyze_network_quality,
+            mcp_server.troubleshoot_slow_internet,
+            mcp_server.troubleshoot_wifi,
+        ],
+    )
+    def test_prompt_declares_prerequisites(self, prompt_fn):
+        text = prompt_fn()
+        assert "Prerequisites:" in text
+
+
+class TestTroubleshootWifiNoPlatformDuplication:
+    """troubleshoot_wifi previously embedded platform-availability notes
+    (macOS / Android / Linux / Windows) that duplicate WifiLinkRecord's
+    docstring. Drop them to keep the prompt as orchestration scaffolding,
+    not a redundant copy of the schema-level contract.
+    """
+
+    @pytest.mark.parametrize("platform", ["macOS", "Android", "Linux", "Windows"])
+    def test_does_not_mention_platform(self, platform):
+        text = mcp_server.troubleshoot_wifi()
+        assert platform not in text, (
+            f"troubleshoot_wifi should not duplicate WifiLinkRecord's "
+            f"platform-availability notes ('{platform}' found in prompt text)"
+        )


### PR DESCRIPTION
## Summary
- Extends the FastMCP `instructions=` block with explicit **Transport**, **Auth**, **Ambient state**, **Server fingerprint**, and a **Does NOT** section so the cold-start surface answers the questions an MCP client asks first.
- Surfaces a versioned capability fingerprint `orbnet@<version>` (sourced from the package-level `orbnet.__version__`) in both the instructions block and the `get_client_info` response, so cached clients can detect drift cheaply when the package version bumps.
- Adds a `Prerequisites:` line to all three prompts and drops `troubleshoot_wifi` step 7's per-platform field-availability bullet — it duplicated `WifiLinkRecord`'s docstring and would rot independently.
- No tool signatures or behavior change. The per-tool `readOnlyHint=True` is unchanged; only its rationale (the polling state is keyed by `caller_id` and lives on the Orb sensor, not in this server) is now declared in the ambient-state section.
- One additive, backwards-compatible response-shape change: `get_client_info` now includes a `server_fingerprint` field. Existing fields and types are untouched.

This is PR 2 of a small follow-up series from the agent-friendliness audit, addressing four findings previously rated Minor (F4, F7, F8, F9). PR 3 will target the error contract (F1, F2).

Independent Codex review pass on the diff before push: confirmed `Auth: None` is accurate (client.py uses only `Accept` + `User-Agent` headers, no token), confirmed `readOnlyHint=True` is honest given every tool is a getter, and flagged that the `caller_id` mechanism is "polling state keyed by id" rather than a cursor — wording tightened accordingly. Codex also noted that the fingerprint is thin (no schema hash) — a deliberate trade-off for a metadata-only PR; will only detect drift when the package version bumps.

## Test plan
- [x] `uv run pytest tests/ -q` — 196 pass, 100% coverage
- [x] `uv run prek run --all-files --hook-stage pre-push` — ruff + ty clean
- [x] Independent Codex review on the diff
- [ ] Manual smoke through an MCP client: confirm the new instructions sections render and `get_client_info` returns `server_fingerprint`