### PR TITLE
feat(mcp): structured error envelope with codes and repair hints

### DIFF
--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import httpx
 
 from .datasets import DATASETS, DatasetSpec, parse_poll_alias
+from .errors import FAMILY_TO_TOOL_NAME, ErrorContext
 from .models import (
     AllDatasetsRequestParams,
     AllDatasetsResponse,
@@ -636,9 +637,17 @@ class OrbAPIClient:
 
         fields: dict[str, Any] = {}
         for (spec, g), result in zip(plan, results, strict=True):
-            fields[spec.response_field(g)] = (
-                ErrorPayload.of(result) if isinstance(result, BaseException) else result
-            )
+            if isinstance(result, BaseException):
+                # `g` is plan-loop-constrained to spec.granularities (tuple of
+                # str literals matching `Granularity`) or `None`, so the cast
+                # is sound.
+                context = ErrorContext(
+                    tool=FAMILY_TO_TOOL_NAME[spec.family],
+                    granularity=cast(Granularity | None, g),
+                )
+                fields[spec.response_field(g)] = ErrorPayload.of(result, context)
+            else:
+                fields[spec.response_field(g)] = result
         return AllDatasetsResponse(**fields)
 
     async def poll_dataset(

--- a/src/orbnet/errors.py
+++ b/src/orbnet/errors.py
@@ -34,7 +34,13 @@ FAMILY_TO_TOOL_NAME: dict[str, str] = {
 """Maps `DatasetSpec.family` values to the canonical MCP tool name. Most
 families round-trip via `f"get_{family}"`; `scores` is the only entry whose
 canonical tool name (`get_scores_1m`) deviates from that pattern, so we keep
-the whole mapping as one explicit table."""
+the whole mapping as one explicit table.
+
+Note: per-tool wrappers in `mcp_server.py` use `<fn>.__name__` so a tool
+rename propagates there automatically. This table is the only place tool
+names are hardcoded; planned tool-name changes (e.g., the `orb_` prefix in
+PR 4 of the agent-friendliness audit) must update both the renamed
+function definitions AND the values in this dict."""
 
 
 class ErrorContext(BaseModel):

--- a/src/orbnet/errors.py
+++ b/src/orbnet/errors.py
@@ -1,0 +1,51 @@
+"""Error translation for the Orb MCP server.
+
+A pure dispatch from raised exceptions (httpx transport errors, HTTP status
+errors, Pydantic validation errors) to structured `ErrorPayload` envelopes
+agents can branch on.
+
+This module is import-light: it depends only on `models` for the types it
+emits. The `translate_exception` function is added in a follow-up task; this
+file currently exposes the lookup tables and the per-call context object.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+from .models import Granularity
+
+GRANULARITY_FALLBACK: dict[Granularity, Granularity | None] = {
+    "1s": "15s",
+    "15s": "1m",
+    "1m": None,
+}
+"""Granularity fallback chain. Keyed by the granularity that failed; value
+is the next one to try, or `None` if the chain is exhausted (1m is the
+most retention-friendly granularity, and if it's unavailable the lower ones
+typically aren't enabled either)."""
+
+
+FAMILY_TO_TOOL_NAME: dict[str, str] = {
+    "scores": "get_scores_1m",
+    "responsiveness": "get_responsiveness",
+    "web_responsiveness": "get_web_responsiveness",
+    "speed_results": "get_speed_results",
+    "wifi_link": "get_wifi_link",
+}
+"""Maps `DatasetSpec.family` values to the canonical MCP tool name. Most
+families round-trip via `f"get_{family}"`; `scores` is the only entry whose
+canonical tool name (`get_scores_1m`) deviates from that pattern, so we keep
+the whole mapping as one explicit table."""
+
+
+class ErrorContext(BaseModel):
+    """Per-call context threaded into `translate_exception`.
+
+    Optional throughout the dispatch — translation works without it but
+    emits weaker repair info (e.g., a 404 with no `tool`/`granularity` set
+    becomes `dataset_not_found` rather than `granularity_unavailable`).
+    """
+
+    tool: str | None = None
+    granularity: Granularity | None = None
+
+    model_config = ConfigDict(extra="forbid")

--- a/src/orbnet/errors.py
+++ b/src/orbnet/errors.py
@@ -5,13 +5,13 @@ errors, Pydantic validation errors) to structured `ErrorPayload` envelopes
 agents can branch on.
 
 This module is import-light: it depends only on `models` for the types it
-emits. The `translate_exception` function is added in a follow-up task; this
-file currently exposes the lookup tables and the per-call context object.
+emits, plus `httpx` and `pydantic` for the exception types it dispatches on.
 """
 
-from pydantic import BaseModel, ConfigDict
+import httpx
+from pydantic import BaseModel, ConfigDict, ValidationError
 
-from .models import Granularity
+from .models import ErrorPayload, Granularity, Repair
 
 GRANULARITY_FALLBACK: dict[Granularity, Granularity | None] = {
     "1s": "15s",
@@ -49,3 +49,81 @@ class ErrorContext(BaseModel):
     granularity: Granularity | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+
+def translate_exception(
+    exc: BaseException, context: ErrorContext | None = None
+) -> ErrorPayload:
+    """Translate a raised exception into a structured `ErrorPayload`.
+
+    Pure: no I/O, no logging, no side effects. Dispatch order matches
+    `docs/superpowers/specs/2026-05-05-mcp-error-contract-design.md`
+    §Translation. First match wins.
+
+    Categorization choices:
+    - All `httpx.NetworkError` subclasses route to `sensor_unreachable`. This
+      covers `ConnectError`, `ReadError`, `WriteError`, `ProtocolError`,
+      `RemoteProtocolError`, etc.
+    - `httpx.ConnectTimeout` is a `TimeoutException` subclass (NOT a
+      `NetworkError` subclass), so it routes to the `timeout` branch below.
+    """
+    if isinstance(exc, httpx.NetworkError):
+        return ErrorPayload(
+            error=str(exc),
+            code="sensor_unreachable",
+            repair=Repair(
+                next_step=(
+                    "verify the sensor is on the network and Local API is enabled"
+                ),
+                alternative="check ORB_HOST and ORB_PORT settings",
+            ),
+        )
+
+    if isinstance(exc, httpx.TimeoutException):
+        return ErrorPayload(
+            error=str(exc),
+            code="timeout",
+            repair=Repair(
+                next_step="increase the timeout parameter, or wait and retry"
+            ),
+        )
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        if exc.response.status_code == 404:
+            return _translate_404(exc, context)
+        return ErrorPayload(error=str(exc), code="http_error")
+
+    if isinstance(exc, ValidationError):
+        return ErrorPayload(error=str(exc), code="validation_failed")
+
+    # Fallthrough: unknown exception. Preserve legacy behaviour (no code,
+    # str(exc) as `error`).
+    return ErrorPayload(error=str(exc))
+
+
+def _translate_404(
+    exc: httpx.HTTPStatusError, context: ErrorContext | None
+) -> ErrorPayload:
+    if context is None or context.tool is None or context.granularity is None:
+        return ErrorPayload(error=str(exc), code="dataset_not_found")
+
+    next_granularity = GRANULARITY_FALLBACK[context.granularity]
+    if next_granularity is not None:
+        repair = Repair(
+            next_step="retry with the next granularity",
+            tool=context.tool,
+            arguments={"granularity": next_granularity},
+        )
+    else:
+        repair = Repair(
+            next_step="escalate to the user; no automated retry available",
+            alternative=(
+                "verify Local API is enabled on the sensor; if 1m is "
+                "unavailable, lower granularities are unlikely to be enabled either"
+            ),
+        )
+    return ErrorPayload(
+        error=str(exc),
+        code="granularity_unavailable",
+        repair=repair,
+    )

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -20,14 +20,17 @@ import os
 import uuid
 from typing import Any
 
+import httpx
 from fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from . import __version__
 from .client import OrbAPIClient
+from .errors import ErrorContext, translate_exception
 from .models import (
     AllDatasetsResponse,
+    ErrorPayload,
     Granularity,
     ResponsivenessRecord,
     ScoreRecord,
@@ -180,7 +183,7 @@ async def get_scores_1m(
     port: int | None = None,
     caller_id: str | None = None,
     timeout: float | None = None,
-) -> list[ScoreRecord]:
+) -> list[ScoreRecord] | ErrorPayload:
     """
     Retrieve 1-minute granularity Scores dataset from an Orb sensor.
 
@@ -255,7 +258,10 @@ async def get_scores_1m(
     """
     client = get_client(host, port, caller_id, timeout)
     await ctx.info(f"Getting 1m scores from Orb sensor {client.host}...")
-    return await client.get_scores_1m()
+    try:
+        return await client.get_scores_1m()
+    except (httpx.HTTPError, ValidationError) as exc:
+        return translate_exception(exc, ErrorContext(tool=get_scores_1m.__name__))
 
 
 @mcp.tool(

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -448,7 +448,7 @@ async def get_wifi_link(
     port: int | None = None,
     caller_id: str | None = None,
     timeout: float | None = None,
-) -> list[WifiLinkRecord]:
+) -> list[WifiLinkRecord] | ErrorPayload:
     """
     Retrieve Wi-Fi Link dataset from an Orb sensor at a single granularity.
 
@@ -506,7 +506,13 @@ async def get_wifi_link(
     """
     client = get_client(host, port, caller_id, timeout)
     await ctx.info(f"Getting Wi-Fi link data from Orb sensor {client.host}...")
-    return await client.get_wifi_link(granularity=granularity)
+    try:
+        return await client.get_wifi_link(granularity=granularity)
+    except (httpx.HTTPError, ValidationError) as exc:
+        return translate_exception(
+            exc,
+            ErrorContext(tool=get_wifi_link.__name__, granularity=granularity),
+        )
 
 
 @mcp.tool(

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -276,7 +276,7 @@ async def get_responsiveness(
     port: int | None = None,
     caller_id: str | None = None,
     timeout: float | None = None,
-) -> list[ResponsivenessRecord]:
+) -> list[ResponsivenessRecord] | ErrorPayload:
     """
     Retrieve Responsiveness dataset from an Orb sensor at a single granularity.
 
@@ -337,7 +337,13 @@ async def get_responsiveness(
     """
     client = get_client(host, port, caller_id, timeout)
     await ctx.info(f"Getting responsiveness data from Orb sensor {client.host}...")
-    return await client.get_responsiveness(granularity=granularity)
+    try:
+        return await client.get_responsiveness(granularity=granularity)
+    except (httpx.HTTPError, ValidationError) as exc:
+        return translate_exception(
+            exc,
+            ErrorContext(tool=get_responsiveness.__name__, granularity=granularity),
+        )
 
 
 @mcp.tool(

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -357,7 +357,7 @@ async def get_web_responsiveness(
     port: int | None = None,
     caller_id: str | None = None,
     timeout: float | None = None,
-) -> list[WebResponsivenessRecord]:
+) -> list[WebResponsivenessRecord] | ErrorPayload:
     """
     Retrieve Web Responsiveness dataset from an Orb sensor.
 
@@ -388,7 +388,12 @@ async def get_web_responsiveness(
     """
     client = get_client(host, port, caller_id, timeout)
     await ctx.info(f"Getting web responsiveness data from Orb sensor {client.host}...")
-    return await client.get_web_responsiveness()
+    try:
+        return await client.get_web_responsiveness()
+    except (httpx.HTTPError, ValidationError) as exc:
+        return translate_exception(
+            exc, ErrorContext(tool=get_web_responsiveness.__name__)
+        )
 
 
 @mcp.tool(
@@ -402,7 +407,7 @@ async def get_speed_results(
     port: int | None = None,
     caller_id: str | None = None,
     timeout: float | None = None,
-) -> list[SpeedRecord]:
+) -> list[SpeedRecord] | ErrorPayload:
     """
     Retrieve Speed test results dataset from an Orb sensor.
 
@@ -433,7 +438,10 @@ async def get_speed_results(
     """
     client = get_client(host, port, caller_id, timeout)
     await ctx.info(f"Getting speed test data from Orb sensor {client.host}...")
-    return await client.get_speed_results()
+    try:
+        return await client.get_speed_results()
+    except (httpx.HTTPError, ValidationError) as exc:
+        return translate_exception(exc, ErrorContext(tool=get_speed_results.__name__))
 
 
 @mcp.tool(

--- a/src/orbnet/models.py
+++ b/src/orbnet/models.py
@@ -469,14 +469,44 @@ class WifiLinkRecord(BaseRecord, BaseIdentifiers, WifiLinkMeasures, WifiLinkDime
 # ============================================================================
 
 
+OrbErrorCode = Literal[
+    "sensor_unreachable",
+    "timeout",
+    "granularity_unavailable",
+    "dataset_not_found",
+    "validation_failed",
+    "http_error",
+]
+
+
+class Repair(BaseModel):
+    """Structured retry hint emitted alongside an `ErrorPayload`.
+
+    `tool` and `arguments` reference real callable surfaces — never free-form
+    prose. When the structured fields don't apply (e.g., the granularity
+    fallback chain is exhausted), `alternative` carries a textual fallback.
+    """
+
+    next_step: str
+    tool: str | None = None
+    arguments: dict[str, Any] | None = None
+    alternative: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class ErrorPayload(BaseModel):
     """Typed error payload for AllDatasetsResponse fields when a dataset fetch fails.
 
-    Serializes to {"error": "..."} and validates from the same shape,
-    preserving the JSON wire format that previously used a bare dict.
+    Serializes to `{"error": "..."}` and validates from the same shape,
+    preserving the JSON wire format. Optional `code` and `repair` fields
+    add machine-readable context; both default to `None` so the legacy
+    bare-`error` shape still validates.
     """
 
     error: str
+    code: OrbErrorCode | None = None
+    repair: Repair | None = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/orbnet/models.py
+++ b/src/orbnet/models.py
@@ -1,7 +1,10 @@
 from collections.abc import Awaitable, Callable
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from .errors import ErrorContext  # noqa: F401
 
 # Time-bucket size for granular datasets (responsiveness, wifi_link). Used in
 # Pydantic Field annotations and public method signatures. Defined here as a
@@ -511,8 +514,20 @@ class ErrorPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     @classmethod
-    def of(cls, exc: BaseException) -> "ErrorPayload":
-        return cls(error=str(exc))
+    def of(
+        cls,
+        exc: BaseException,
+        context: "ErrorContext | None" = None,
+    ) -> "ErrorPayload":
+        """Translate an exception into a structured `ErrorPayload`.
+
+        Routes through `orbnet.errors.translate_exception`. Imports lazily to
+        avoid a circular dependency with `errors.py`. Optional `context`
+        populates `tool` / `granularity` repair fields when the caller has them.
+        """
+        from .errors import translate_exception
+
+        return translate_exception(exc, context)
 
 
 type DatasetResult[T] = list[T] | ErrorPayload

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1004,3 +1004,38 @@ class TestGranularityValidation:
         client = OrbAPIClient(host="192.168.1.100")
         with pytest.raises(ValueError, match="1s, 15s, 1m"):
             await client.get_responsiveness(granularity="bogus")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
+
+
+class TestGetAllDatasetsErrorContext:
+    """When a per-fetch task in get_all_datasets raises, the resulting
+    ErrorPayload must include the structured code/repair from
+    translate_exception, with `tool` and `granularity` populated from the
+    plan loop."""
+
+    async def test_partial_404_includes_repair_arguments(self, mocker):
+        import httpx
+
+        from orbnet.client import OrbAPIClient
+        from orbnet.models import ErrorPayload
+
+        client = OrbAPIClient(host="h")
+        request = httpx.Request(
+            "GET", "http://h:7080/api/v2/datasets/responsiveness_1s.json"
+        )
+        response = httpx.Response(404, request=request)
+
+        async def fake_fetch(spec, granularity, caller_id, **kwargs):
+            if spec.family == "responsiveness" and granularity == "1s":
+                raise httpx.HTTPStatusError("404", request=request, response=response)
+            return []
+
+        mocker.patch.object(client, "_fetch", side_effect=fake_fetch)
+
+        result = await client.get_all_datasets(include_all_responsiveness=True)
+
+        partial = result.responsiveness_1s
+        assert isinstance(partial, ErrorPayload)
+        assert partial.code == "granularity_unavailable"
+        assert partial.repair is not None
+        assert partial.repair.tool == "get_responsiveness"
+        assert partial.repair.arguments == {"granularity": "15s"}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,107 @@
+"""Tests for orbnet.errors translation logic.
+
+Pure unit tests on the dispatch from raised exceptions to ErrorPayload —
+no I/O, no FastMCP wiring.
+"""
+
+import httpx
+import pytest
+
+from orbnet.errors import (
+    FAMILY_TO_TOOL_NAME,
+    GRANULARITY_FALLBACK,
+    ErrorContext,
+)
+from orbnet.models import Granularity
+
+# ---------------------------------------------------------------------------
+# Helpers for constructing httpx exceptions in tests
+# ---------------------------------------------------------------------------
+
+
+def _make_status_error(
+    status: int,
+    url: str = "http://localhost:7080/api/v2/datasets/responsiveness_1s.json",
+) -> httpx.HTTPStatusError:
+    """Build an `httpx.HTTPStatusError` with a populated request and response.
+
+    httpx's status errors carry both objects on the exception, and downstream
+    code (and the translator we'll write next) reads `.response.status_code`
+    to dispatch.
+    """
+    request = httpx.Request("GET", url)
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"{status} status", request=request, response=response)
+
+
+# ---------------------------------------------------------------------------
+# Helper sanity check
+# ---------------------------------------------------------------------------
+
+
+class TestMakeStatusErrorHelper:
+    """Sanity check for the helper used by Task 3's translation tests.
+    Without this, the helper is dead code in this commit."""
+
+    def test_carries_status_code_request_and_response(self):
+        err = _make_status_error(404)
+        assert err.response.status_code == 404
+        assert err.request.method == "GET"
+        assert "/datasets/responsiveness_1s.json" in str(err.request.url)
+
+    def test_accepts_custom_url(self):
+        err = _make_status_error(500, url="http://other:1234/api/x.json")
+        assert err.response.status_code == 500
+        assert "http://other:1234/api/x.json" in str(err.request.url)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestGranularityFallbackChain:
+    @pytest.mark.parametrize(
+        ("current", "expected_next"),
+        [("1s", "15s"), ("15s", "1m"), ("1m", None)],
+    )
+    def test_chain_advances(self, current: Granularity, expected_next):
+        assert GRANULARITY_FALLBACK[current] == expected_next
+
+    def test_chain_keys_match_granularity_literal(self):
+        """When the Granularity literal grows, the fallback chain must keep up.
+
+        Compares against the literal's runtime args so a bare addition to
+        Granularity (without updating GRANULARITY_FALLBACK) trips this test.
+        """
+        from typing import get_args
+
+        from orbnet.models import Granularity
+
+        granularity_values = set(get_args(Granularity.__value__))
+        assert set(GRANULARITY_FALLBACK.keys()) == granularity_values
+
+
+class TestFamilyToToolName:
+    def test_scores_family_maps_to_versioned_name(self):
+        assert FAMILY_TO_TOOL_NAME["scores"] == "get_scores_1m"
+
+    @pytest.mark.parametrize(
+        "family",
+        ["responsiveness", "web_responsiveness", "speed_results", "wifi_link"],
+    )
+    def test_other_families_round_trip(self, family: str):
+        assert FAMILY_TO_TOOL_NAME[family] == f"get_{family}"
+
+
+class TestErrorContext:
+    def test_defaults_to_all_none(self):
+        ctx = ErrorContext()
+        assert ctx.tool is None
+        assert ctx.granularity is None
+
+    def test_extra_fields_forbidden(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ErrorContext(tool="get_responsiveness", bogus="x")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -105,3 +105,114 @@ class TestErrorContext:
 
         with pytest.raises(ValidationError):
             ErrorContext(tool="get_responsiveness", bogus="x")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+
+
+# ---------------------------------------------------------------------------
+# translate_exception dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateExceptionDispatch:
+    """Pin every dispatch branch in translate_exception. First match wins;
+    order matches the spec's §Translation."""
+
+    def test_connect_error_is_sensor_unreachable(self):
+        from orbnet.errors import translate_exception
+
+        payload = translate_exception(httpx.ConnectError("conn refused"))
+        assert payload.code == "sensor_unreachable"
+        assert payload.repair is not None
+        assert "Local API" in payload.repair.next_step
+        assert payload.repair.alternative is not None
+        assert "ORB_HOST" in payload.repair.alternative
+
+    def test_network_error_is_sensor_unreachable(self):
+        from orbnet.errors import translate_exception
+
+        payload = translate_exception(httpx.NetworkError("network down"))
+        assert payload.code == "sensor_unreachable"
+
+    def test_timeout_exception_is_timeout(self):
+        from orbnet.errors import translate_exception
+
+        payload = translate_exception(httpx.TimeoutException("slow"))
+        assert payload.code == "timeout"
+        assert payload.repair is not None
+        assert "timeout" in payload.repair.next_step.lower()
+
+    def test_404_without_context_is_dataset_not_found(self):
+        from orbnet.errors import translate_exception
+
+        payload = translate_exception(_make_status_error(404), context=None)
+        assert payload.code == "dataset_not_found"
+
+    def test_404_with_tool_but_no_granularity_is_dataset_not_found(self):
+        from orbnet.errors import translate_exception
+
+        ctx = ErrorContext(tool="get_speed_results")
+        payload = translate_exception(_make_status_error(404), context=ctx)
+        assert payload.code == "dataset_not_found"
+
+    def test_500_is_http_error(self):
+        from orbnet.errors import translate_exception
+
+        payload = translate_exception(_make_status_error(500))
+        assert payload.code == "http_error"
+
+    def test_validation_error_is_validation_failed(self):
+        from pydantic import TypeAdapter, ValidationError
+
+        from orbnet.errors import translate_exception
+
+        try:
+            TypeAdapter(int).validate_python("not-an-int")
+        except ValidationError as exc:
+            payload = translate_exception(exc)
+        assert payload.code == "validation_failed"
+        assert payload.repair is None  # no machine-actionable repair
+
+    def test_unknown_exception_falls_through(self):
+        from orbnet.errors import translate_exception
+
+        payload = translate_exception(RuntimeError("surprise"))
+        assert payload.code is None
+        assert payload.repair is None
+        assert "surprise" in payload.error
+
+
+class TestGranularityRepairChain:
+    """When a 404 happens on a granular tool, the repair hint must point to
+    the next granularity in the fallback chain. When the failed granularity
+    is the last in the chain (1m), `repair.alternative` carries the
+    escalation cue rather than `repair = None`."""
+
+    @pytest.mark.parametrize(
+        ("failed", "expected_next"),
+        [("1s", "15s"), ("15s", "1m")],
+    )
+    def test_404_with_granular_context_suggests_next(
+        self, failed: Granularity, expected_next: Granularity
+    ):
+        from orbnet.errors import translate_exception
+
+        ctx = ErrorContext(tool="get_responsiveness", granularity=failed)
+        payload = translate_exception(_make_status_error(404), context=ctx)
+
+        assert payload.code == "granularity_unavailable"
+        assert payload.repair is not None
+        assert payload.repair.tool == "get_responsiveness"
+        assert payload.repair.arguments == {"granularity": expected_next}
+        assert payload.repair.alternative is None
+
+    def test_404_at_last_granularity_populates_alternative(self):
+        from orbnet.errors import translate_exception
+
+        ctx = ErrorContext(tool="get_responsiveness", granularity="1m")
+        payload = translate_exception(_make_status_error(404), context=ctx)
+
+        assert payload.code == "granularity_unavailable"
+        assert payload.repair is not None
+        assert payload.repair.tool is None
+        assert payload.repair.arguments is None
+        assert payload.repair.alternative is not None
+        assert "Local API" in payload.repair.alternative

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -509,6 +509,46 @@ class TestGetScores1mErrorEnvelope:
         assert result.repair is not None
 
 
+class TestGetResponsivenessErrorEnvelope:
+    async def test_404_at_1s_suggests_15s(self, mock_client, ctx):
+        import httpx
+
+        request = httpx.Request(
+            "GET", "http://h:7080/api/v2/datasets/responsiveness_1s.json"
+        )
+        response = httpx.Response(404, request=request)
+        mock_client.get_responsiveness.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        result = await mcp_server.get_responsiveness(ctx, host="h", granularity="1s")
+
+        assert isinstance(result, ErrorPayload)
+        assert result.code == "granularity_unavailable"
+        assert result.repair is not None
+        assert result.repair.tool == "get_responsiveness"
+        assert result.repair.arguments == {"granularity": "15s"}
+
+    async def test_404_at_1m_populates_alternative(self, mock_client, ctx):
+        import httpx
+
+        request = httpx.Request(
+            "GET", "http://h:7080/api/v2/datasets/responsiveness_1m.json"
+        )
+        response = httpx.Response(404, request=request)
+        mock_client.get_responsiveness.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        result = await mcp_server.get_responsiveness(ctx, host="h", granularity="1m")
+
+        assert isinstance(result, ErrorPayload)
+        assert result.code == "granularity_unavailable"
+        assert result.repair is not None
+        assert result.repair.arguments is None
+        assert result.repair.alternative is not None
+
+
 class TestMCPOutputSchemaIsUnion:
     """FastMCP derives outputSchema from each tool's return-type annotation.
     After widening to `list[X] | ErrorPayload`, the schema must accept both
@@ -519,6 +559,7 @@ class TestMCPOutputSchemaIsUnion:
         "tool_name",
         [
             "get_scores_1m",
+            "get_responsiveness",
             # Other widened tools added in later tasks.
         ],
     )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -312,7 +312,10 @@ async def test_get_all_datasets_error_payload_passthrough(mock_client, ctx):
     result = await mcp_server.get_all_datasets(ctx, host="h")
 
     assert isinstance(result, AllDatasetsResponse)
-    dumped = result.model_dump()
+    # exclude_none preserves the legacy bare error wire format; the
+    # extended ErrorPayload's optional code/repair default to None and
+    # are omitted.
+    dumped = result.model_dump(exclude_none=True)
     assert dumped["responsiveness_1s"] == {"error": "connection refused"}
     assert dumped["scores_1m"] == []
     mock_client.get_all_datasets.assert_awaited_once_with(

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -630,5 +630,17 @@ class TestMCPOutputSchemaIsUnion:
         if "properties" in schema and "result" in schema["properties"]:
             candidates.append(schema["properties"]["result"])
 
-        union_found = any("anyOf" in c or "oneOf" in c for c in candidates)
-        assert union_found, f"{tool_name} output schema is not a union: {schema}"
+        # Require not just *a* union node, but a union with >=2 branches. A
+        # regression where FastMCP/Pydantic collapsed the union to a single
+        # `anyOf: [<one>]` would pass the bare-existence check silently.
+        def _union_branches(c: dict) -> int:
+            for key in ("anyOf", "oneOf"):
+                if key in c and isinstance(c[key], list):
+                    return len(c[key])
+            return 0
+
+        best = max((_union_branches(c) for c in candidates), default=0)
+        assert best >= 2, (
+            f"{tool_name} output schema is not a multi-branch union "
+            f"(best union arity: {best}): {schema}"
+        )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -570,6 +570,36 @@ class TestGetWifiLinkErrorEnvelope:
         assert result.repair.arguments == {"granularity": "15s"}
 
 
+class TestGetWebResponsivenessErrorEnvelope:
+    async def test_404_is_dataset_not_found(self, mock_client, ctx):
+        import httpx
+
+        request = httpx.Request(
+            "GET", "http://h:7080/api/v2/datasets/web_responsiveness_results.json"
+        )
+        response = httpx.Response(404, request=request)
+        mock_client.get_web_responsiveness.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        result = await mcp_server.get_web_responsiveness(ctx, host="h")
+
+        assert isinstance(result, ErrorPayload)
+        assert result.code == "dataset_not_found"
+
+
+class TestGetSpeedResultsErrorEnvelope:
+    async def test_timeout_emits_timeout_code(self, mock_client, ctx):
+        import httpx
+
+        mock_client.get_speed_results.side_effect = httpx.TimeoutException("slow")
+
+        result = await mcp_server.get_speed_results(ctx, host="h")
+
+        assert isinstance(result, ErrorPayload)
+        assert result.code == "timeout"
+
+
 class TestMCPOutputSchemaIsUnion:
     """FastMCP derives outputSchema from each tool's return-type annotation.
     After widening to `list[X] | ErrorPayload`, the schema must accept both
@@ -582,6 +612,8 @@ class TestMCPOutputSchemaIsUnion:
             "get_scores_1m",
             "get_responsiveness",
             "get_wifi_link",
+            "get_web_responsiveness",
+            "get_speed_results",
             # Other widened tools added in later tasks.
         ],
     )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -549,6 +549,27 @@ class TestGetResponsivenessErrorEnvelope:
         assert result.repair.alternative is not None
 
 
+class TestGetWifiLinkErrorEnvelope:
+    async def test_404_at_1s_suggests_15s(self, mock_client, ctx):
+        import httpx
+
+        request = httpx.Request(
+            "GET", "http://h:7080/api/v2/datasets/wifi_link_1s.json"
+        )
+        response = httpx.Response(404, request=request)
+        mock_client.get_wifi_link.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        result = await mcp_server.get_wifi_link(ctx, host="h", granularity="1s")
+
+        assert isinstance(result, ErrorPayload)
+        assert result.code == "granularity_unavailable"
+        assert result.repair is not None
+        assert result.repair.tool == "get_wifi_link"
+        assert result.repair.arguments == {"granularity": "15s"}
+
+
 class TestMCPOutputSchemaIsUnion:
     """FastMCP derives outputSchema from each tool's return-type annotation.
     After widening to `list[X] | ErrorPayload`, the schema must accept both
@@ -560,6 +581,7 @@ class TestMCPOutputSchemaIsUnion:
         [
             "get_scores_1m",
             "get_responsiveness",
+            "get_wifi_link",
             # Other widened tools added in later tasks.
         ],
     )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -489,3 +489,51 @@ class TestTroubleshootWifiNoPlatformDuplication:
             f"troubleshoot_wifi should not duplicate WifiLinkRecord's "
             f"platform-availability notes ('{platform}' found in prompt text)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-tool error envelope: widened return type + structured ErrorPayload
+# ---------------------------------------------------------------------------
+
+
+class TestGetScores1mErrorEnvelope:
+    async def test_returns_error_payload_on_connect_error(self, mock_client, ctx):
+        import httpx
+
+        mock_client.get_scores_1m.side_effect = httpx.ConnectError("conn refused")
+
+        result = await mcp_server.get_scores_1m(ctx, host="h")
+
+        assert isinstance(result, ErrorPayload)
+        assert result.code == "sensor_unreachable"
+        assert result.repair is not None
+
+
+class TestMCPOutputSchemaIsUnion:
+    """FastMCP derives outputSchema from each tool's return-type annotation.
+    After widening to `list[X] | ErrorPayload`, the schema must accept both
+    branches — pin this so MCP clients see an additive shape change rather
+    than a regression."""
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "get_scores_1m",
+            # Other widened tools added in later tasks.
+        ],
+    )
+    async def test_output_schema_accepts_array_or_error_payload(self, tool_name: str):
+        tool = await mcp_server.mcp.get_tool(tool_name)
+        assert tool is not None
+        schema = tool.output_schema
+        assert schema is not None, f"{tool_name} has no output schema"
+
+        # Pydantic emits unions as `anyOf`. Look for a union-shaped top level
+        # OR a wrapped union one level deep; FastMCP wraps result schemas
+        # with a `result` key in some versions.
+        candidates = [schema]
+        if "properties" in schema and "result" in schema["properties"]:
+            candidates.append(schema["properties"]["result"])
+
+        union_found = any("anyOf" in c or "oneOf" in c for c in candidates)
+        assert union_found, f"{tool_name} output schema is not a union: {schema}"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1387,3 +1387,24 @@ class TestExtendedErrorPayload:
 
         with pytest.raises(ValidationError):
             ErrorPayload(error="x", code="bogus_code")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+
+
+class TestErrorPayloadOfRoutesThroughTranslator:
+    """`ErrorPayload.of(exc)` must produce a structured payload for known
+    exception types (sensor_unreachable, timeout, http_error, etc.). Unknown
+    exceptions still fall through to `error=str(exc)` with `code=None`."""
+
+    def test_connect_error_emits_sensor_unreachable(self):
+        import httpx
+
+        from orbnet.models import ErrorPayload
+
+        payload = ErrorPayload.of(httpx.ConnectError("conn refused"))
+        assert payload.code == "sensor_unreachable"
+
+    def test_unknown_exception_has_no_code(self):
+        from orbnet.models import ErrorPayload
+
+        payload = ErrorPayload.of(RuntimeError("surprise"))
+        assert payload.code is None
+        assert "surprise" in payload.error

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1019,7 +1019,9 @@ class TestErrorPayload:
         from orbnet.models import ErrorPayload
 
         payload = ErrorPayload(error="boom")
-        assert payload.model_dump() == {"error": "boom"}
+        # exclude_none preserves the legacy bare wire format; new optional
+        # fields (code, repair) default to None.
+        assert payload.model_dump(exclude_none=True) == {"error": "boom"}
 
     def test_error_payload_validates_from_dict(self):
         from orbnet.models import ErrorPayload
@@ -1282,7 +1284,10 @@ class TestAllDatasetsResponseWireFormat:
             speed_results=[],
             wifi_link_1m=[WifiLinkRecord(**r) for r in sample_wifi_link_data],
         )
-        dumped = response.model_dump()
+        # exclude_none preserves the legacy bare error wire format; the
+        # extended ErrorPayload's optional code/repair default to None and
+        # are omitted.
+        dumped = response.model_dump(exclude_none=True)
         assert dumped["responsiveness_1m"] == {"error": "boom"}
 
     def test_error_field_validates_from_error_dict(
@@ -1301,3 +1306,84 @@ class TestAllDatasetsResponseWireFormat:
         )
         assert isinstance(response.responsiveness_1m, ErrorPayload)
         assert response.responsiveness_1m.error == "boom"
+
+
+# ---------------------------------------------------------------------------
+# Error envelope: Repair + extended ErrorPayload
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPayloadBackwardsCompat:
+    """Existing wire format `{"error": "..."}` must still validate after adding
+    optional `code` and `repair` fields. Pin this so future schema changes
+    can't silently break consumers caching the old shape."""
+
+    def test_legacy_payload_validates(self):
+        from orbnet.models import ErrorPayload
+
+        payload = ErrorPayload(error="connection refused")
+        assert payload.error == "connection refused"
+        assert payload.code is None
+        assert payload.repair is None
+
+    def test_legacy_payload_serializes_bare_when_none_excluded(self):
+        from orbnet.models import ErrorPayload
+
+        payload = ErrorPayload(error="connection refused")
+        assert payload.model_dump(exclude_none=True) == {"error": "connection refused"}
+
+
+class TestRepair:
+    def test_minimal_construction_with_only_next_step(self):
+        from orbnet.models import Repair
+
+        r = Repair(next_step="retry with the next granularity")
+        assert r.next_step == "retry with the next granularity"
+        assert r.tool is None
+        assert r.arguments is None
+        assert r.alternative is None
+
+    def test_full_construction(self):
+        from orbnet.models import Repair
+
+        r = Repair(
+            next_step="retry with the next granularity",
+            tool="get_responsiveness",
+            arguments={"granularity": "15s"},
+        )
+        assert r.tool == "get_responsiveness"
+        assert r.arguments == {"granularity": "15s"}
+
+    def test_extra_fields_forbidden(self):
+        from pydantic import ValidationError
+
+        from orbnet.models import Repair
+
+        with pytest.raises(ValidationError):
+            Repair(next_step="x", bogus="y")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+
+
+class TestExtendedErrorPayload:
+    def test_accepts_code_and_repair(self):
+        from orbnet.models import ErrorPayload, Repair
+
+        payload = ErrorPayload(
+            error="404",
+            code="granularity_unavailable",
+            repair=Repair(
+                next_step="retry with the next granularity",
+                tool="get_responsiveness",
+                arguments={"granularity": "15s"},
+            ),
+        )
+        assert payload.code == "granularity_unavailable"
+        assert payload.repair is not None
+        assert payload.repair.arguments == {"granularity": "15s"}
+
+    def test_invalid_code_rejected(self):
+        from pydantic import ValidationError
+
+        from orbnet.models import ErrorPayload
+
+        with pytest.raises(ValidationError):
+            ErrorPayload(error="x", code="bogus_code")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Summary
- Adds a structured error envelope to the MCP server so agents can branch on machine-readable failures and act on machine-readable repair hints (most notably the granularity-fallback chain).
- New `src/orbnet/errors.py` module with a pure `translate_exception` function, the `GRANULARITY_FALLBACK` chain, and a `FAMILY_TO_TOOL_NAME` table.
- `ErrorPayload` extended with optional `code` and `repair` fields; wire format is additive (legacy `{"error": "..."}` payloads still validate and serialize bare under `exclude_none=True`).
- Five per-dataset MCP tools widen their return type to `list[X] | ErrorPayload` and catch `(httpx.HTTPError, ValidationError)` via the translator.
- The aggregated `get_all_datasets` partial-failure path threads the same `ErrorContext` so partial failures match the per-tool error envelope.

This is PR 3 of the agent-friendliness audit follow-up series, addressing F1 (no symbolic codes / no repair hints / no retryability signal) and F2 (granularity fallback rule lives only in prose).

Independent Codex review pass on the full diff before push (final items: tightened the schema-union test from "any anyOf" to "≥2-branch anyOf" so a regression to a single-branch union can't pass silently; added a PR 4 forward-pointer comment on `FAMILY_TO_TOOL_NAME` flagging it as a hardcoded string table the planned `orb_` rename will need to update).

## Test plan
- [x] `uv run pytest tests/ -q` — 241 pass, 100% coverage
- [x] `uv run prek run --all-files --hook-stage pre-push` — clean
- [x] Codex review on the full diff
- [ ] Manual smoke against a live Orb sensor: confirm 404 on a granular dataset produces ErrorPayload with `code="granularity_unavailable"` and `repair.arguments.granularity` pointing to the next chain entry