### PR TITLE
chore(mcp): drop client-unactionable metadata from instructions block

### DIFF
--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -41,18 +41,13 @@ SERVER_FINGERPRINT = f"orbnet@{__version__}"
 # Initialize FastMCP server
 mcp = FastMCP(
     "Orb Network Quality Data",
-    instructions=f"""
+    instructions="""
     This server provides real-time network quality monitoring from Orb sensors.
 
-    **Server fingerprint:** {SERVER_FINGERPRINT}
-    **Transport:** stdio
-    **Auth:** None — sensor must be reachable on the local network with Local API enabled
-    **Ambient state:** Reads ORB_HOST, ORB_PORT, ORB_TIMEOUT env vars (cached
-    after first tool call). Polling state is keyed by a session-specific
-    caller_id: the Orb sensor uses that id to track which records each caller
-    has already seen and returns only new ones on subsequent calls. Because
-    the polling state lives on the sensor (not this MCP server), per-tool
-    readOnlyHint=True remains accurate.
+    **Stateful polling:** Each tool call sends a caller_id that's fixed for
+    this server process's lifetime. The Orb sensor uses that id to track
+    which records each caller has already seen, returning only new ones on
+    subsequent calls.
 
     **What You Can Ask:**
     ✓ "What's my current network quality?"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -393,9 +393,10 @@ class TestLazyConfigLoading:
 
 
 # ---------------------------------------------------------------------------
-# Discoverability surface (PR 2 — F4/F7/F8/F9):
-#   - Server instructions declare transport, auth, ambient state, fingerprint,
-#     and explicit negative scope.
+# Discoverability surface:
+#   - Server instructions carry only client-actionable information: stateful
+#     polling semantics and explicit negative scope (no transport/auth/env-var
+#     declarations — those don't help an agent that has already connected).
 #   - get_client_info exposes a server fingerprint.
 #   - Prompts list prerequisites and avoid duplicating model-level platform
 #     notes.
@@ -403,9 +404,10 @@ class TestLazyConfigLoading:
 
 
 class TestServerInstructions:
-    """The instructions block is what an MCP client reads at cold start —
-    transport, auth, ambient state, negative scope, and the capability
-    fingerprint must all be discoverable from this single text.
+    """The instructions block is what an MCP client reads at cold start. It
+    must carry the client-actionable bits (stateful-polling behavior and
+    negative scope) without leaking server-operator metadata an agent
+    can't act on.
     """
 
     @pytest.fixture
@@ -415,24 +417,19 @@ class TestServerInstructions:
     @pytest.mark.parametrize(
         "anchor",
         [
-            "Transport:",
-            "Auth:",
-            "Ambient state:",
-            "Server fingerprint:",
+            "Stateful polling:",
             "Does NOT",
         ],
     )
     def test_declares_section(self, text, anchor):
         assert anchor in text, f"server instructions should declare '{anchor}'"
 
-    def test_fingerprint_includes_version(self, text):
-        from orbnet import __version__
-
-        assert f"orbnet@{__version__}" in text
-
-    @pytest.mark.parametrize("env_var", ["ORB_HOST", "ORB_PORT", "ORB_TIMEOUT"])
-    def test_lists_ambient_env_vars(self, text, env_var):
-        assert env_var in text
+    def test_stateful_polling_describes_substantive_behavior(self, text):
+        """Header presence is necessary but not sufficient — the section must
+        carry the behavior agents need to interpret repeated tool calls
+        correctly. Pin the load-bearing tokens against wording regressions."""
+        assert "caller_id" in text
+        assert "only new" in text
 
 
 class TestGetClientInfoFingerprint:


### PR DESCRIPTION
## Summary
PR 2 added Transport, Auth, Ambient state, and Server fingerprint declarations to the FastMCP `instructions` block. Spotted in review: an MCP client that's already connected to the server can't act on most of that — it's already on the transport, env vars are out of reach, and the auth model is a no-op.

This trims the instructions to carry only client-actionable information:

- **Drop**:
  - `Server fingerprint:` — already surfaced (parseably) in `get_client_info`'s response. No need to also stuff it in the unstructured instructions string.
  - `Transport: stdio` — tautological for a connected client.
  - `Auth: None — sensor must be reachable…` — no-op for the client; the Local-API-enabled requirement is already in the existing **Troubleshooting** block lower down.
  - `Ambient state: ORB_HOST/ORB_PORT/ORB_TIMEOUT env vars …` — client can't change env vars from session.
- **Keep, tightened** under a new `**Stateful polling:**` header: the actual behavior agents need to interpret repeated tool calls correctly (caller_id is process-fixed; sensor returns only new records on subsequent calls). Drops the "readOnlyHint=True remains accurate" meta-justification that was internal documentation leaking onto the agent surface.
- **Keep**: the `**Does NOT:**` section (genuinely useful for negative-scope discovery), and all pre-PR-2 content.

The fingerprint stays in `get_client_info`'s response — `TestGetClientInfoFingerprint` continues to pin that.

Independent Codex review pass on the diff before push: confirmed the trimmed block is coherent (no later section depends on the removed lines), flagged a wording mismatch ("session-specific caller_id" vs the actual process-lifetime scoping — fixed to "fixed for this server process's lifetime"), and recommended pinning the substantive polling-state content rather than just the header — added `test_stateful_polling_describes_substantive_behavior` asserting `caller_id` and `only new` appear in the instructions text.

## Test plan
- [x] `uv run pytest tests/ -q` — 190 pass, 100% coverage
- [x] `uv run prek run --all-files --hook-stage pre-push` — clean
- [x] Independent Codex review on the diff
- [ ] Manual smoke through an MCP client: confirm the `instructions` field renders without the dropped sections and the polling-state line is intact