### PR TITLE
docs: add CHANGELOG with backfilled entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Structured error envelope: `Repair` model, `OrbErrorCode` literal,
+  `translate_exception` dispatch, granularity-fallback repair hints, and
+  MCP tool return-type widening to `list[X] | ErrorPayload` (#27)
+- Server discoverability: `Does NOT` section in instructions block,
+  stateful-polling declaration, `server_fingerprint` in
+  `get_client_info`, and `Prerequisites:` line on prompts (#26)
+- FastMCP 3.2 support with typed `ToolAnnotations`, first-class `title=`
+  and `tags=` on tools/prompts (#21)
+
+### Changed
+
+- **BREAKING:** Dropped FastMCP 2.x support; `fastmcp>=3.2.0` is now
+  required (#21)
+- Aligned MCP tool granularity defaults to `1m` to match the underlying
+  client (the MCP layer previously defaulted to `1s` while the client
+  defaulted to `1m`, producing different behavior depending on entry
+  point) (#25)
+- Tightened FastMCP `instructions` to carry only client-actionable
+  information; dropped Transport, Auth, Server-fingerprint, and
+  env-var Ambient-state lines added in #26. The fingerprint remains
+  surfaced via `get_client_info` (#28)
+- Modernized typing to Python 3.13 conventions (#24)
+- Lazy config loading; tightened `PollingCallback` typing (#23)
+
+### Fixed
+
+- Correctness bugs in client and MCP server: granularity validation
+  and host validation at the boundary (#22)
+
+## [0.2.0] - 2026-02-21
+
+### Added
+
+- Wi-Fi Link dataset support (#4)
+- Coverage reporting via new `check_coverage` CI workflow (#3)
+
+## [0.1.3] - 2025-10-05
+
+### Changed
+
+- Return Pydantic objects from client methods (#2)
+
+## [0.1.2] - 2025-10-03
+
+### Changed
+
+- MCP server discoverability: server instructions, tool annotations, MCP resources, and config validation (#1)
+
+## [0.1.0] - 2025-10-02
+
+### Added
+
+- Initial release.


### PR DESCRIPTION
## Summary

Establishes a project CHANGELOG following the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format.

- Past tagged releases (`v0.1.0` → `v0.2.0`) get one-line summaries; pre-release archaeology is out of scope.
- The `[Unreleased]` section backfills PRs #21–#28: FastMCP 3.2 modernization, correctness bugs, Python 3.13 typing, lazy config + callback typing, the four-PR agent-friendliness audit follow-up series (granularity defaults #25, discoverability #26, error contract #27, instructions trim #28).

PR-B (the `orb_` service-prefix tool rename — F5+F6 of the audit) lands after this and appends to the `[Unreleased]` section's Changed subsection.

Independent Codex review pass on the diff before push: caught a missed PR #3 attribution under v0.2.0 (added as a separate `Coverage reporting via new check_coverage CI workflow` bullet), tightened thin entries (PR #1's "Enhanced MCP server" → "MCP server discoverability: server instructions, tool annotations, MCP resources, and config validation"), and added an `### Added` subsection under v0.1.0 for structural consistency. One categorization disagreement noted: PR #25 stays under Changed (visible default-behavior change) rather than Fixed (commit prefix); spec-review approval defended this placement.

## Test plan

- [x] `uv run prek run --files CHANGELOG.md --hook-stage pre-push` — clean
- [x] Spot-check PR attributions against `git log --merges` — verified
- [x] Spot-check past-release dates against `git log -1 <tag>` — verified
- [x] Independent Codex review on the diff