### PR TITLE
refactor(mcp)!: rename tools with orb_ prefix; drop _1m suffix from scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Renamed all seven MCP tools with the `orb_` service
+  prefix to reduce ambiguity in multi-server contexts. `get_scores_1m`
+  also drops the `_1m` suffix because the Scores dataset is
+  single-granularity at the Orb API level. No deprecation aliases —
+  old names are gone. Migration:
+  - `get_scores_1m` → `orb_get_scores`
+  - `get_responsiveness` → `orb_get_responsiveness`
+  - `get_speed_results` → `orb_get_speed_results`
+  - `get_web_responsiveness` → `orb_get_web_responsiveness`
+  - `get_wifi_link` → `orb_get_wifi_link`
+  - `get_all_datasets` → `orb_get_all_datasets`
+  - `get_client_info` → `orb_get_client_info`
+
+  Direct Python users of `OrbAPIClient` see no method-signature changes.
+  Note: `ErrorPayload.repair.tool` values emitted via
+  `OrbAPIClient.get_all_datasets`'s partial-failure path now reflect the
+  new MCP tool names (the `tool` field is documented as the canonical
+  MCP tool to retry with).
 - **BREAKING:** Dropped FastMCP 2.x support; `fastmcp>=3.2.0` is now
   required (#21)
 - Aligned MCP tool granularity defaults to `1m` to match the underlying

--- a/src/orbnet/errors.py
+++ b/src/orbnet/errors.py
@@ -25,22 +25,20 @@ typically aren't enabled either)."""
 
 
 FAMILY_TO_TOOL_NAME: dict[str, str] = {
-    "scores": "get_scores_1m",
-    "responsiveness": "get_responsiveness",
-    "web_responsiveness": "get_web_responsiveness",
-    "speed_results": "get_speed_results",
-    "wifi_link": "get_wifi_link",
+    "scores": "orb_get_scores",
+    "responsiveness": "orb_get_responsiveness",
+    "web_responsiveness": "orb_get_web_responsiveness",
+    "speed_results": "orb_get_speed_results",
+    "wifi_link": "orb_get_wifi_link",
 }
-"""Maps `DatasetSpec.family` values to the canonical MCP tool name. Most
-families round-trip via `f"get_{family}"`; `scores` is the only entry whose
-canonical tool name (`get_scores_1m`) deviates from that pattern, so we keep
-the whole mapping as one explicit table.
+"""Maps `DatasetSpec.family` values to the canonical MCP tool name.
 
-Note: per-tool wrappers in `mcp_server.py` use `<fn>.__name__` so a tool
-rename propagates there automatically. This table is the only place tool
-names are hardcoded; planned tool-name changes (e.g., the `orb_` prefix in
-PR 4 of the agent-friendliness audit) must update both the renamed
-function definitions AND the values in this dict."""
+Each MCP per-tool wrapper uses `<fn>.__name__` to populate
+`ErrorContext.tool` automatically; this table is the single hand-maintained
+mapping used by `OrbAPIClient.get_all_datasets`'s partial-failure path,
+where the loop iterates `(spec, granularity)` pairs and needs to map
+`spec.family` to the public tool name to thread into `ErrorContext`.
+"""
 
 
 class ErrorContext(BaseModel):

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -87,16 +87,16 @@ mcp = FastMCP(
     If a request for a specific granularity returns an error or empty data,
     you MUST try the other granularities for that same dataset before moving
     on to a different dataset. The fallback order is: 1s → 15s → 1m.
-    For example, if get_wifi_link(granularity="1s") fails, try "15s",
+    For example, if orb_get_wifi_link(granularity="1s") fails, try "15s",
     then "1m" before concluding that Wi-Fi link data is unavailable.
 
     **Tool Selection Guide:**
-    - Quick check? → get_scores_1m() (fastest, gives overall picture)
-    - Detailed troubleshooting? → get_all_datasets() (comprehensive)
-    - Video call problems? → get_responsiveness() (latency/jitter focus)
-    - Slow downloads? → get_speed_results() (bandwidth focus)
-    - Web browsing issues? → get_web_responsiveness() (page load focus)
-    - Weak Wi-Fi signal? → get_wifi_link() (RSSI, SNR, link rates)
+    - Quick check? → orb_get_scores() (fastest, gives overall picture)
+    - Detailed troubleshooting? → orb_get_all_datasets() (comprehensive)
+    - Video call problems? → orb_get_responsiveness() (latency/jitter focus)
+    - Slow downloads? → orb_get_speed_results() (bandwidth focus)
+    - Web browsing issues? → orb_get_web_responsiveness() (page load focus)
+    - Weak Wi-Fi signal? → orb_get_wifi_link() (RSSI, SNR, link rates)
 
     **Built-in Workflows:**
     Use prompts like 'analyze_network_quality', 'troubleshoot_slow_internet', or
@@ -168,11 +168,11 @@ def get_client(
 
 
 @mcp.tool(
-    title="Get Scores Dataset (1m)",
+    title="Get Scores Dataset",
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     tags={"orb", "scores"},
 )
-async def get_scores_1m(
+async def orb_get_scores(
     ctx: Context,
     host: str | None = None,
     port: int | None = None,
@@ -256,7 +256,7 @@ async def get_scores_1m(
     try:
         return await client.get_scores_1m()
     except (httpx.HTTPError, ValidationError) as exc:
-        return translate_exception(exc, ErrorContext(tool=get_scores_1m.__name__))
+        return translate_exception(exc, ErrorContext(tool=orb_get_scores.__name__))
 
 
 @mcp.tool(
@@ -264,7 +264,7 @@ async def get_scores_1m(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     tags={"orb", "responsiveness"},
 )
-async def get_responsiveness(
+async def orb_get_responsiveness(
     ctx: Context,
     host: str | None = None,
     granularity: Granularity = "1m",
@@ -276,7 +276,7 @@ async def get_responsiveness(
     Retrieve Responsiveness dataset from an Orb sensor at a single granularity.
 
     This tool fetches ONE granularity at a time. To fetch all granularities at
-    once, use get_all_datasets(include_all_responsiveness=True) instead.
+    once, use orb_get_all_datasets(include_all_responsiveness=True) instead.
 
     Includes detailed network responsiveness measures including lag, latency,
     jitter, and packet loss. Available in 1-second, 15-second, and 1-minute buckets.
@@ -337,7 +337,7 @@ async def get_responsiveness(
     except (httpx.HTTPError, ValidationError) as exc:
         return translate_exception(
             exc,
-            ErrorContext(tool=get_responsiveness.__name__, granularity=granularity),
+            ErrorContext(tool=orb_get_responsiveness.__name__, granularity=granularity),
         )
 
 
@@ -346,7 +346,7 @@ async def get_responsiveness(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     tags={"orb", "web-performance"},
 )
-async def get_web_responsiveness(
+async def orb_get_web_responsiveness(
     ctx: Context,
     host: str | None = None,
     port: int | None = None,
@@ -387,7 +387,7 @@ async def get_web_responsiveness(
         return await client.get_web_responsiveness()
     except (httpx.HTTPError, ValidationError) as exc:
         return translate_exception(
-            exc, ErrorContext(tool=get_web_responsiveness.__name__)
+            exc, ErrorContext(tool=orb_get_web_responsiveness.__name__)
         )
 
 
@@ -396,7 +396,7 @@ async def get_web_responsiveness(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     tags={"orb", "speed"},
 )
-async def get_speed_results(
+async def orb_get_speed_results(
     ctx: Context,
     host: str | None = None,
     port: int | None = None,
@@ -436,7 +436,9 @@ async def get_speed_results(
     try:
         return await client.get_speed_results()
     except (httpx.HTTPError, ValidationError) as exc:
-        return translate_exception(exc, ErrorContext(tool=get_speed_results.__name__))
+        return translate_exception(
+            exc, ErrorContext(tool=orb_get_speed_results.__name__)
+        )
 
 
 @mcp.tool(
@@ -444,7 +446,7 @@ async def get_speed_results(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     tags={"orb", "wifi"},
 )
-async def get_wifi_link(
+async def orb_get_wifi_link(
     ctx: Context,
     host: str | None = None,
     granularity: Granularity = "1m",
@@ -456,7 +458,7 @@ async def get_wifi_link(
     Retrieve Wi-Fi Link dataset from an Orb sensor at a single granularity.
 
     This tool fetches ONE granularity at a time. To fetch all granularities at
-    once, use get_all_datasets(include_all_wifi_link=True) instead.
+    once, use orb_get_all_datasets(include_all_wifi_link=True) instead.
 
     Includes signal quality and link-layer metrics for the active Wi-Fi
     connection: signal strength (RSSI), signal-to-noise ratio (SNR), transmit
@@ -514,7 +516,7 @@ async def get_wifi_link(
     except (httpx.HTTPError, ValidationError) as exc:
         return translate_exception(
             exc,
-            ErrorContext(tool=get_wifi_link.__name__, granularity=granularity),
+            ErrorContext(tool=orb_get_wifi_link.__name__, granularity=granularity),
         )
 
 
@@ -523,7 +525,7 @@ async def get_wifi_link(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     tags={"orb", "aggregate"},
 )
-async def get_all_datasets(
+async def orb_get_all_datasets(
     ctx: Context,
     host: str | None = None,
     include_all_responsiveness: bool = False,
@@ -645,7 +647,7 @@ def _get_client_info_impl(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False),
     tags={"orb", "config"},
 )
-def get_client_info(
+def orb_get_client_info(
     host: str | None = None,
     port: int | None = None,
     caller_id: str | None = None,
@@ -662,10 +664,10 @@ def analyze_network_quality() -> str:
     **Prerequisites:** Orb sensor reachable on the network with Local API enabled.
 
     Analyze the network quality using these steps:
-    1. Call get_scores_1m() to get the latest Orb scores
+    1. Call orb_get_scores() to get the latest Orb scores
     2. Examine orb_score (0-100, higher is better)
     3. Check component scores: responsiveness_score, reliability_score, speed_score
-    4. If scores are low, call get_responsiveness() for detailed metrics
+    4. If scores are low, call orb_get_responsiveness() for detailed metrics
     5. Provide actionable insights about network performance
     """
 
@@ -679,9 +681,9 @@ def troubleshoot_slow_internet() -> str:
     **Prerequisites:** Orb sensor reachable on the network with Local API enabled.
 
     To troubleshoot slow internet:
-    1. Call get_speed_results() to check recent speed tests
-    2. Call get_responsiveness() for latency/jitter data
-    3. Call get_web_responsiveness() to check TTFB and DNS performance
+    1. Call orb_get_speed_results() to check recent speed tests
+    2. Call orb_get_responsiveness() for latency/jitter data
+    3. Call orb_get_web_responsiveness() to check TTFB and DNS performance
     4. Compare metrics against typical values:
        - Good latency: < 50ms
        - Good jitter: < 10ms
@@ -698,7 +700,7 @@ def troubleshoot_wifi() -> str:
     Wi-Fi Link data is unavailable on iOS or ethernet-connected sensors.
 
     To diagnose Wi-Fi-specific network issues:
-    1. Call get_wifi_link() to get signal and link metrics
+    1. Call orb_get_wifi_link() to get signal and link metrics
     2. Examine key signal indicators:
        - rssi_avg: Signal strength in dBm (good: > -65, poor: < -75)
        - snr_avg: Signal-to-noise ratio in dB (good: > 25, poor: < 15)
@@ -710,9 +712,9 @@ def troubleshoot_wifi() -> str:
        - channel_number: Overlapping channels cause interference
        - phy_mode: Older standards (802.11n) have lower max throughput than
          802.11ac or 802.11ax
-    4. Call get_responsiveness() to check if poor Wi-Fi signal
+    4. Call orb_get_responsiveness() to check if poor Wi-Fi signal
        correlates with high latency or packet loss
-    5. Call get_speed_results() to check if signal weakness is limiting throughput
+    5. Call orb_get_speed_results() to check if signal weakness is limiting throughput
     6. Correlate the metrics:
        - Low RSSI + high latency = device too far from access point
        - Low SNR + packet loss = RF interference (neighboring networks, appliances)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1037,5 +1037,5 @@ class TestGetAllDatasetsErrorContext:
         assert isinstance(partial, ErrorPayload)
         assert partial.code == "granularity_unavailable"
         assert partial.repair is not None
-        assert partial.repair.tool == "get_responsiveness"
+        assert partial.repair.tool == "orb_get_responsiveness"
         assert partial.repair.arguments == {"granularity": "15s"}

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -83,15 +83,15 @@ class TestGranularityFallbackChain:
 
 
 class TestFamilyToToolName:
-    def test_scores_family_maps_to_versioned_name(self):
-        assert FAMILY_TO_TOOL_NAME["scores"] == "get_scores_1m"
+    def test_scores_family_maps_to_orb_get_scores(self):
+        assert FAMILY_TO_TOOL_NAME["scores"] == "orb_get_scores"
 
     @pytest.mark.parametrize(
         "family",
         ["responsiveness", "web_responsiveness", "speed_results", "wifi_link"],
     )
     def test_other_families_round_trip(self, family: str):
-        assert FAMILY_TO_TOOL_NAME[family] == f"get_{family}"
+        assert FAMILY_TO_TOOL_NAME[family] == f"orb_get_{family}"
 
 
 class TestErrorContext:
@@ -104,7 +104,7 @@ class TestErrorContext:
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError):
-            ErrorContext(tool="get_responsiveness", bogus="x")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+            ErrorContext(tool="orb_get_responsiveness", bogus="x")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +149,7 @@ class TestTranslateExceptionDispatch:
     def test_404_with_tool_but_no_granularity_is_dataset_not_found(self):
         from orbnet.errors import translate_exception
 
-        ctx = ErrorContext(tool="get_speed_results")
+        ctx = ErrorContext(tool="orb_get_speed_results")
         payload = translate_exception(_make_status_error(404), context=ctx)
         assert payload.code == "dataset_not_found"
 
@@ -195,19 +195,19 @@ class TestGranularityRepairChain:
     ):
         from orbnet.errors import translate_exception
 
-        ctx = ErrorContext(tool="get_responsiveness", granularity=failed)
+        ctx = ErrorContext(tool="orb_get_responsiveness", granularity=failed)
         payload = translate_exception(_make_status_error(404), context=ctx)
 
         assert payload.code == "granularity_unavailable"
         assert payload.repair is not None
-        assert payload.repair.tool == "get_responsiveness"
+        assert payload.repair.tool == "orb_get_responsiveness"
         assert payload.repair.arguments == {"granularity": expected_next}
         assert payload.repair.alternative is None
 
     def test_404_at_last_granularity_populates_alternative(self):
         from orbnet.errors import translate_exception
 
-        ctx = ErrorContext(tool="get_responsiveness", granularity="1m")
+        ctx = ErrorContext(tool="orb_get_responsiveness", granularity="1m")
         payload = translate_exception(_make_status_error(404), context=ctx)
 
         assert payload.code == "granularity_unavailable"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -36,39 +36,39 @@ def ctx():
     return c
 
 
-async def test_get_scores_1m_tool(mock_client, ctx):
-    result = await mcp_server.get_scores_1m(ctx, host="h")
+async def test_orb_get_scores_tool(mock_client, ctx):
+    result = await mcp_server.orb_get_scores(ctx, host="h")
     assert result == []
     mock_client.get_scores_1m.assert_awaited_once()
     ctx.info.assert_awaited_once()
 
 
-async def test_get_responsiveness_tool(mock_client, ctx):
-    result = await mcp_server.get_responsiveness(ctx, host="h", granularity="1s")
+async def test_orb_get_responsiveness_tool(mock_client, ctx):
+    result = await mcp_server.orb_get_responsiveness(ctx, host="h", granularity="1s")
     assert result == []
     mock_client.get_responsiveness.assert_awaited_once_with(granularity="1s")
 
 
-async def test_get_web_responsiveness_tool(mock_client, ctx):
-    result = await mcp_server.get_web_responsiveness(ctx, host="h")
+async def test_orb_get_web_responsiveness_tool(mock_client, ctx):
+    result = await mcp_server.orb_get_web_responsiveness(ctx, host="h")
     assert result == []
     mock_client.get_web_responsiveness.assert_awaited_once()
 
 
-async def test_get_speed_results_tool(mock_client, ctx):
-    result = await mcp_server.get_speed_results(ctx, host="h")
+async def test_orb_get_speed_results_tool(mock_client, ctx):
+    result = await mcp_server.orb_get_speed_results(ctx, host="h")
     assert result == []
     mock_client.get_speed_results.assert_awaited_once()
 
 
-async def test_get_wifi_link_tool(mock_client, ctx):
-    result = await mcp_server.get_wifi_link(ctx, host="h", granularity="15s")
+async def test_orb_get_wifi_link_tool(mock_client, ctx):
+    result = await mcp_server.orb_get_wifi_link(ctx, host="h", granularity="15s")
     assert result == []
     mock_client.get_wifi_link.assert_awaited_once_with(granularity="15s")
 
 
-async def test_get_all_datasets_tool(mock_client, ctx):
-    result = await mcp_server.get_all_datasets(
+async def test_orb_get_all_datasets_tool(mock_client, ctx):
+    result = await mcp_server.orb_get_all_datasets(
         ctx, host="h", include_all_responsiveness=True, include_all_wifi_link=True
     )
     assert result == {}
@@ -79,14 +79,14 @@ async def test_get_all_datasets_tool(mock_client, ctx):
     )
 
 
-def test_get_client_info_tool(mock_client):
+def test_orb_get_client_info_tool(mock_client):
     mock_client.host = "h"
     mock_client.port = 7080
     mock_client.base_url = "http://h:7080"
     mock_client.caller_id = "cid"
     mock_client.timeout = 30.0
 
-    info = mcp_server.get_client_info(host="h")
+    info = mcp_server.orb_get_client_info(host="h")
     assert info["host"] == "h"
     assert info["caller_id"] == "cid"
 
@@ -94,19 +94,19 @@ def test_get_client_info_tool(mock_client):
 def test_analyze_network_quality_prompt():
     text = mcp_server.analyze_network_quality()
     assert isinstance(text, str)
-    assert "get_scores_1m" in text
+    assert "orb_get_scores" in text
 
 
 def test_troubleshoot_slow_internet_prompt():
     text = mcp_server.troubleshoot_slow_internet()
     assert isinstance(text, str)
-    assert "get_speed_results" in text
+    assert "orb_get_speed_results" in text
 
 
 def test_troubleshoot_wifi_prompt():
     text = mcp_server.troubleshoot_wifi()
     assert isinstance(text, str)
-    assert "get_wifi_link" in text
+    assert "orb_get_wifi_link" in text
 
 
 def test_main_invokes_mcp_run(mocker):
@@ -123,8 +123,8 @@ def test_main_invokes_mcp_run(mocker):
 @pytest.mark.parametrize(
     ("mcp_tool", "client_method"),
     [
-        (mcp_server.get_responsiveness, OrbAPIClient.get_responsiveness),
-        (mcp_server.get_wifi_link, OrbAPIClient.get_wifi_link),
+        (mcp_server.orb_get_responsiveness, OrbAPIClient.get_responsiveness),
+        (mcp_server.orb_get_wifi_link, OrbAPIClient.get_wifi_link),
     ],
 )
 def test_mcp_tool_granularity_default_matches_client(mcp_tool, client_method):
@@ -137,12 +137,15 @@ def test_mcp_tool_granularity_default_matches_client(mcp_tool, client_method):
     )
 
 
-async def test_get_all_datasets_forwards_client_default_granularity(mock_client, ctx):
-    """get_all_datasets does not currently expose default_granularity to MCP callers,
-    so it must forward whatever the underlying client treats as default. This locks
-    the MCP-layer hardcode to track the client default if either side moves.
+async def test_orb_get_all_datasets_forwards_client_default_granularity(
+    mock_client, ctx
+):
+    """orb_get_all_datasets does not currently expose default_granularity to MCP
+    callers, so it must forward whatever the underlying client treats as default.
+    This locks the MCP-layer hardcode to track the client default if either side
+    moves.
     """
-    await mcp_server.get_all_datasets(ctx, host="h")
+    await mcp_server.orb_get_all_datasets(ctx, host="h")
     call_kwargs = mock_client.get_all_datasets.await_args.kwargs
     client_default = (
         inspect.signature(OrbAPIClient.get_all_datasets)
@@ -155,8 +158,8 @@ async def test_get_all_datasets_forwards_client_default_granularity(mock_client,
 @pytest.mark.parametrize(
     ("mcp_tool", "client_method_attr"),
     [
-        (mcp_server.get_responsiveness, "get_responsiveness"),
-        (mcp_server.get_wifi_link, "get_wifi_link"),
+        (mcp_server.orb_get_responsiveness, "get_responsiveness"),
+        (mcp_server.orb_get_wifi_link, "get_wifi_link"),
     ],
 )
 async def test_mcp_tool_no_arg_forwards_client_default_granularity(
@@ -177,10 +180,10 @@ async def test_mcp_tool_no_arg_forwards_client_default_granularity(
 # ---------------------------------------------------------------------------
 
 
-async def test_tool_metadata_get_scores_1m():
-    tool = await mcp_server.mcp.get_tool("get_scores_1m")
+async def test_tool_metadata_orb_get_scores():
+    tool = await mcp_server.mcp.get_tool("orb_get_scores")
     assert tool is not None
-    assert tool.title == "Get Scores Dataset (1m)"
+    assert tool.title == "Get Scores Dataset"
     assert tool.tags == {"orb", "scores"}
     assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
@@ -188,8 +191,8 @@ async def test_tool_metadata_get_scores_1m():
     assert tool.annotations.idempotentHint is None
 
 
-async def test_tool_metadata_get_responsiveness():
-    tool = await mcp_server.mcp.get_tool("get_responsiveness")
+async def test_tool_metadata_orb_get_responsiveness():
+    tool = await mcp_server.mcp.get_tool("orb_get_responsiveness")
     assert tool is not None
     assert tool.title == "Get Responsiveness Dataset"
     assert tool.tags == {"orb", "responsiveness"}
@@ -199,8 +202,8 @@ async def test_tool_metadata_get_responsiveness():
     assert tool.annotations.idempotentHint is None
 
 
-async def test_tool_metadata_get_web_responsiveness():
-    tool = await mcp_server.mcp.get_tool("get_web_responsiveness")
+async def test_tool_metadata_orb_get_web_responsiveness():
+    tool = await mcp_server.mcp.get_tool("orb_get_web_responsiveness")
     assert tool is not None
     assert tool.title == "Get Web Responsiveness Dataset"
     assert tool.tags == {"orb", "web-performance"}
@@ -210,8 +213,8 @@ async def test_tool_metadata_get_web_responsiveness():
     assert tool.annotations.idempotentHint is None
 
 
-async def test_tool_metadata_get_speed_results():
-    tool = await mcp_server.mcp.get_tool("get_speed_results")
+async def test_tool_metadata_orb_get_speed_results():
+    tool = await mcp_server.mcp.get_tool("orb_get_speed_results")
     assert tool is not None
     assert tool.title == "Get Speed Test Results"
     assert tool.tags == {"orb", "speed"}
@@ -221,8 +224,8 @@ async def test_tool_metadata_get_speed_results():
     assert tool.annotations.idempotentHint is None
 
 
-async def test_tool_metadata_get_wifi_link():
-    tool = await mcp_server.mcp.get_tool("get_wifi_link")
+async def test_tool_metadata_orb_get_wifi_link():
+    tool = await mcp_server.mcp.get_tool("orb_get_wifi_link")
     assert tool is not None
     assert tool.title == "Get Wi-Fi Link Dataset"
     assert tool.tags == {"orb", "wifi"}
@@ -232,8 +235,8 @@ async def test_tool_metadata_get_wifi_link():
     assert tool.annotations.idempotentHint is None
 
 
-async def test_tool_metadata_get_all_datasets():
-    tool = await mcp_server.mcp.get_tool("get_all_datasets")
+async def test_tool_metadata_orb_get_all_datasets():
+    tool = await mcp_server.mcp.get_tool("orb_get_all_datasets")
     assert tool is not None
     assert tool.title == "Get All Datasets"
     assert tool.tags == {"orb", "aggregate"}
@@ -243,8 +246,8 @@ async def test_tool_metadata_get_all_datasets():
     assert tool.annotations.idempotentHint is None
 
 
-async def test_tool_metadata_get_client_info():
-    tool = await mcp_server.mcp.get_tool("get_client_info")
+async def test_tool_metadata_orb_get_client_info():
+    tool = await mcp_server.mcp.get_tool("orb_get_client_info")
     assert tool is not None
     assert tool.title == "Get Client Configuration"
     assert tool.tags == {"orb", "config"}
@@ -284,13 +287,13 @@ async def test_registered_tools_and_prompts():
     tools = await mcp_server.mcp.list_tools()
     prompts = await mcp_server.mcp.list_prompts()
     assert {t.name for t in tools} == {
-        "get_scores_1m",
-        "get_responsiveness",
-        "get_web_responsiveness",
-        "get_speed_results",
-        "get_wifi_link",
-        "get_all_datasets",
-        "get_client_info",
+        "orb_get_scores",
+        "orb_get_responsiveness",
+        "orb_get_web_responsiveness",
+        "orb_get_speed_results",
+        "orb_get_wifi_link",
+        "orb_get_all_datasets",
+        "orb_get_client_info",
     }
     assert {p.name for p in prompts} == {
         "analyze_network_quality",
@@ -299,7 +302,7 @@ async def test_registered_tools_and_prompts():
     }
 
 
-async def test_get_all_datasets_error_payload_passthrough(mock_client, ctx):
+async def test_orb_get_all_datasets_error_payload_passthrough(mock_client, ctx):
     error_payload = ErrorPayload(error="connection refused")
     response = AllDatasetsResponse(
         scores_1m=[],
@@ -309,7 +312,7 @@ async def test_get_all_datasets_error_payload_passthrough(mock_client, ctx):
     )
     mock_client.get_all_datasets = AsyncMock(return_value=response)
 
-    result = await mcp_server.get_all_datasets(ctx, host="h")
+    result = await mcp_server.orb_get_all_datasets(ctx, host="h")
 
     assert isinstance(result, AllDatasetsResponse)
     # exclude_none preserves the legacy bare error wire format; the
@@ -359,7 +362,7 @@ async def test_log_uses_resolved_host_not_raw_arg(mock_client, ctx):
     (from config), not literal 'None'."""
     mock_client.host = "resolved-host"
 
-    await mcp_server.get_scores_1m(ctx, host=None)
+    await mcp_server.orb_get_scores(ctx, host=None)
 
     ctx.info.assert_awaited_once()
     log_message = ctx.info.await_args.args[0]
@@ -435,8 +438,8 @@ class TestServerInstructions:
         assert "only new" in text
 
 
-class TestGetClientInfoFingerprint:
-    """get_client_info should surface the server fingerprint so agents that
+class TestOrbGetClientInfoFingerprint:
+    """orb_get_client_info should surface the server fingerprint so agents that
     skip the instructions block can still discover the version they're against.
     """
 
@@ -449,7 +452,7 @@ class TestGetClientInfoFingerprint:
         mock_client.caller_id = "cid"
         mock_client.timeout = 30.0
 
-        info = mcp_server.get_client_info(host="h")
+        info = mcp_server.orb_get_client_info(host="h")
 
         assert info["server_fingerprint"] == f"orbnet@{__version__}"
 
@@ -493,20 +496,20 @@ class TestTroubleshootWifiNoPlatformDuplication:
 # ---------------------------------------------------------------------------
 
 
-class TestGetScores1mErrorEnvelope:
+class TestOrbGetScoresErrorEnvelope:
     async def test_returns_error_payload_on_connect_error(self, mock_client, ctx):
         import httpx
 
         mock_client.get_scores_1m.side_effect = httpx.ConnectError("conn refused")
 
-        result = await mcp_server.get_scores_1m(ctx, host="h")
+        result = await mcp_server.orb_get_scores(ctx, host="h")
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "sensor_unreachable"
         assert result.repair is not None
 
 
-class TestGetResponsivenessErrorEnvelope:
+class TestOrbGetResponsivenessErrorEnvelope:
     async def test_404_at_1s_suggests_15s(self, mock_client, ctx):
         import httpx
 
@@ -518,12 +521,14 @@ class TestGetResponsivenessErrorEnvelope:
             "404", request=request, response=response
         )
 
-        result = await mcp_server.get_responsiveness(ctx, host="h", granularity="1s")
+        result = await mcp_server.orb_get_responsiveness(
+            ctx, host="h", granularity="1s"
+        )
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "granularity_unavailable"
         assert result.repair is not None
-        assert result.repair.tool == "get_responsiveness"
+        assert result.repair.tool == "orb_get_responsiveness"
         assert result.repair.arguments == {"granularity": "15s"}
 
     async def test_404_at_1m_populates_alternative(self, mock_client, ctx):
@@ -537,7 +542,9 @@ class TestGetResponsivenessErrorEnvelope:
             "404", request=request, response=response
         )
 
-        result = await mcp_server.get_responsiveness(ctx, host="h", granularity="1m")
+        result = await mcp_server.orb_get_responsiveness(
+            ctx, host="h", granularity="1m"
+        )
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "granularity_unavailable"
@@ -546,7 +553,7 @@ class TestGetResponsivenessErrorEnvelope:
         assert result.repair.alternative is not None
 
 
-class TestGetWifiLinkErrorEnvelope:
+class TestOrbGetWifiLinkErrorEnvelope:
     async def test_404_at_1s_suggests_15s(self, mock_client, ctx):
         import httpx
 
@@ -558,16 +565,16 @@ class TestGetWifiLinkErrorEnvelope:
             "404", request=request, response=response
         )
 
-        result = await mcp_server.get_wifi_link(ctx, host="h", granularity="1s")
+        result = await mcp_server.orb_get_wifi_link(ctx, host="h", granularity="1s")
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "granularity_unavailable"
         assert result.repair is not None
-        assert result.repair.tool == "get_wifi_link"
+        assert result.repair.tool == "orb_get_wifi_link"
         assert result.repair.arguments == {"granularity": "15s"}
 
 
-class TestGetWebResponsivenessErrorEnvelope:
+class TestOrbGetWebResponsivenessErrorEnvelope:
     async def test_404_is_dataset_not_found(self, mock_client, ctx):
         import httpx
 
@@ -579,19 +586,19 @@ class TestGetWebResponsivenessErrorEnvelope:
             "404", request=request, response=response
         )
 
-        result = await mcp_server.get_web_responsiveness(ctx, host="h")
+        result = await mcp_server.orb_get_web_responsiveness(ctx, host="h")
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "dataset_not_found"
 
 
-class TestGetSpeedResultsErrorEnvelope:
+class TestOrbGetSpeedResultsErrorEnvelope:
     async def test_timeout_emits_timeout_code(self, mock_client, ctx):
         import httpx
 
         mock_client.get_speed_results.side_effect = httpx.TimeoutException("slow")
 
-        result = await mcp_server.get_speed_results(ctx, host="h")
+        result = await mcp_server.orb_get_speed_results(ctx, host="h")
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "timeout"
@@ -606,11 +613,11 @@ class TestMCPOutputSchemaIsUnion:
     @pytest.mark.parametrize(
         "tool_name",
         [
-            "get_scores_1m",
-            "get_responsiveness",
-            "get_wifi_link",
-            "get_web_responsiveness",
-            "get_speed_results",
+            "orb_get_scores",
+            "orb_get_responsiveness",
+            "orb_get_wifi_link",
+            "orb_get_web_responsiveness",
+            "orb_get_speed_results",
             # Other widened tools added in later tasks.
         ],
     )
@@ -641,3 +648,23 @@ class TestMCPOutputSchemaIsUnion:
             f"{tool_name} output schema is not a multi-branch union "
             f"(best union arity: {best}): {schema}"
         )
+
+
+async def test_old_tool_names_are_not_registered():
+    """The hard rename to orb_get_* must not leave the old names
+    discoverable. PR 4's rationale assumes a clean surface — a residual
+    old-name registration would silently undo that."""
+    tools = await mcp_server.mcp.list_tools()
+    names = {t.name for t in tools}
+    old_names = {
+        "get_scores_1m",
+        "get_responsiveness",
+        "get_web_responsiveness",
+        "get_speed_results",
+        "get_wifi_link",
+        "get_all_datasets",
+        "get_client_info",
+    }
+    assert names.isdisjoint(old_names), (
+        f"old tool names still registered: {names & old_names}"
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1348,10 +1348,10 @@ class TestRepair:
 
         r = Repair(
             next_step="retry with the next granularity",
-            tool="get_responsiveness",
+            tool="orb_get_responsiveness",
             arguments={"granularity": "15s"},
         )
-        assert r.tool == "get_responsiveness"
+        assert r.tool == "orb_get_responsiveness"
         assert r.arguments == {"granularity": "15s"}
 
     def test_extra_fields_forbidden(self):
@@ -1372,7 +1372,7 @@ class TestExtendedErrorPayload:
             code="granularity_unavailable",
             repair=Repair(
                 next_step="retry with the next granularity",
-                tool="get_responsiveness",
+                tool="orb_get_responsiveness",
                 arguments={"granularity": "15s"},
             ),
         )


### PR DESCRIPTION
## Summary

**BREAKING CHANGE.** Hard-rename all seven MCP tool functions with the `orb_` service prefix. The Scores tool also drops `_1m` because the Scores dataset is single-granularity at the Orb API level. No deprecation aliases.

## Migration

| Old MCP tool name | New MCP tool name |
|---|---|
| `get_scores_1m` | `orb_get_scores` |
| `get_responsiveness` | `orb_get_responsiveness` |
| `get_speed_results` | `orb_get_speed_results` |
| `get_web_responsiveness` | `orb_get_web_responsiveness` |
| `get_wifi_link` | `orb_get_wifi_link` |
| `get_all_datasets` | `orb_get_all_datasets` |
| `get_client_info` | `orb_get_client_info` |

The Scores tool's title also drops `(1m)` (was `Get Scores Dataset (1m)` → `Get Scores Dataset`).

**Direct `OrbAPIClient` Python-API method names DO NOT change** — those Python entry points stay as-is, out of scope for this rename.

## Why

- **F5** of the agent-friendliness audit: bare verb+noun tool names risk collision in multi-server contexts where agents see a flat tool list.
- **F6**: `get_scores_1m` baked granularity into the name while sibling granular tools take it as a parameter — internal-consistency cleanup.

This is PR 4 (PR-B) of the audit follow-up series. PR-A (#29) added the CHANGELOG; this PR appends the rename entry under `[Unreleased]` Changed with the full migration mapping inlined.

Independent Codex review pass on the diff before push.

## Test plan
- [x] `uv run pytest tests/ -q` — 236 pass, 100% coverage
- [x] `uv run prek run --all-files --hook-stage pre-push` — clean
- [x] Cross-cutting grep verification with PCRE word boundaries (only Python-API references and the intentional regression-test old-name listing remain)
- [x] New regression test `test_old_tool_names_are_not_registered` asserts old names are no longer discoverable via `mcp.list_tools()`
- [x] Independent Codex review on the diff (one item caught: CHANGELOG inlined the migration mapping rather than deferring to PR description; amended)
- [ ] Manual smoke through an MCP client: confirm each new `orb_*` tool name is discoverable and functions identically to its pre-rename counterpart