### PR TITLE
refactor: tighten DatasetSpec granularity types; collapse ErrorPayload.of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Internal cleanup: tightened `DatasetSpec.granularities` typing from
+  `tuple[str, ...]` to `tuple[Granularity, ...]` (and same for
+  `default_granularity`), eliminating a runtime-no-op `cast` in
+  `OrbAPIClient.get_all_datasets`'s partial-failure path. Also removed
+  the redundant `ErrorPayload.of` classmethod — its only call site
+  now invokes `translate_exception` directly. No public-API change.
 - **BREAKING:** Renamed all seven MCP tools with the `orb_` service
   prefix to reduce ambiguity in multi-server contexts. `get_scores_1m`
   also drops the `_1m` suffix because the Scores dataset is

--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -8,11 +8,10 @@ from typing import Any, cast
 import httpx
 
 from .datasets import DATASETS, DatasetSpec, parse_poll_alias
-from .errors import FAMILY_TO_TOOL_NAME, ErrorContext
+from .errors import FAMILY_TO_TOOL_NAME, ErrorContext, translate_exception
 from .models import (
     AllDatasetsRequestParams,
     AllDatasetsResponse,
-    ErrorPayload,
     Granularity,
     OrbClientConfig,
     PollingCallback,
@@ -176,7 +175,7 @@ class OrbAPIClient:
     async def _fetch(
         self,
         spec: DatasetSpec,
-        granularity: str | None = None,
+        granularity: Granularity | None = None,
         caller_id: str | None = None,
         **params,
     ) -> list[Any]:
@@ -614,7 +613,7 @@ class OrbAPIClient:
             "wifi_link": request.include_all_wifi_link,
         }
 
-        plan: list[tuple[DatasetSpec, str | None]] = []
+        plan: list[tuple[DatasetSpec, Granularity | None]] = []
         for spec in DATASETS.values():
             if not spec.granularities:
                 plan.append((spec, None))
@@ -638,14 +637,11 @@ class OrbAPIClient:
         fields: dict[str, Any] = {}
         for (spec, g), result in zip(plan, results, strict=True):
             if isinstance(result, BaseException):
-                # `g` is plan-loop-constrained to spec.granularities (tuple of
-                # str literals matching `Granularity`) or `None`, so the cast
-                # is sound.
                 context = ErrorContext(
                     tool=FAMILY_TO_TOOL_NAME[spec.family],
-                    granularity=cast(Granularity | None, g),
+                    granularity=g,
                 )
-                fields[spec.response_field(g)] = ErrorPayload.of(result, context)
+                fields[spec.response_field(g)] = translate_exception(result, context)
             else:
                 fields[spec.response_field(g)] = result
         return AllDatasetsResponse(**fields)

--- a/src/orbnet/datasets.py
+++ b/src/orbnet/datasets.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 
 from .models import (
     BaseRecord,
+    Granularity,
     ResponsivenessRecord,
     ScoreRecord,
     SpeedRecord,
@@ -38,18 +39,18 @@ class DatasetSpec:
 
     family: str
     record_class: type[BaseRecord]
-    granularities: tuple[str, ...] = ()
-    default_granularity: str | None = None
+    granularities: tuple[Granularity, ...] = ()
+    default_granularity: Granularity | None = None
     wire_name_override: str | None = None
 
-    def wire_name(self, granularity: str | None = None) -> str:
+    def wire_name(self, granularity: Granularity | None = None) -> str:
         if self.wire_name_override is not None:
             return self.wire_name_override
         if self.granularities:
             return f"{self.family}_{granularity or self.default_granularity}"
         return self.family
 
-    def response_field(self, granularity: str | None = None) -> str:
+    def response_field(self, granularity: Granularity | None = None) -> str:
         if self.granularities:
             return f"{self.family}_{granularity or self.default_granularity}"
         return self.family
@@ -88,8 +89,8 @@ DATASETS: dict[str, DatasetSpec] = {
 
 def _build_poll_aliases(
     datasets: dict[str, DatasetSpec],
-) -> dict[str, tuple[DatasetSpec, str | None]]:
-    aliases: dict[str, tuple[DatasetSpec, str | None]] = {}
+) -> dict[str, tuple[DatasetSpec, Granularity | None]]:
+    aliases: dict[str, tuple[DatasetSpec, Granularity | None]] = {}
     for spec in datasets.values():
         if spec.granularities:
             for g in spec.granularities:
@@ -99,10 +100,12 @@ def _build_poll_aliases(
     return aliases
 
 
-POLL_ALIASES: dict[str, tuple[DatasetSpec, str | None]] = _build_poll_aliases(DATASETS)
+POLL_ALIASES: dict[str, tuple[DatasetSpec, Granularity | None]] = _build_poll_aliases(
+    DATASETS
+)
 
 
-def parse_poll_alias(name: str) -> tuple[DatasetSpec, str | None]:
+def parse_poll_alias(name: str) -> tuple[DatasetSpec, Granularity | None]:
     """Resolve a wire-name string (as accepted by poll_dataset) to (spec, granularity).
 
     Raises ValueError with the list of valid options if `name` is unknown.

--- a/src/orbnet/models.py
+++ b/src/orbnet/models.py
@@ -1,10 +1,7 @@
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
-
-if TYPE_CHECKING:
-    from .errors import ErrorContext  # noqa: F401
 
 # Time-bucket size for granular datasets (responsiveness, wifi_link). Used in
 # Pydantic Field annotations and public method signatures. Defined here as a
@@ -512,22 +509,6 @@ class ErrorPayload(BaseModel):
     repair: Repair | None = None
 
     model_config = ConfigDict(extra="forbid")
-
-    @classmethod
-    def of(
-        cls,
-        exc: BaseException,
-        context: "ErrorContext | None" = None,
-    ) -> "ErrorPayload":
-        """Translate an exception into a structured `ErrorPayload`.
-
-        Routes through `orbnet.errors.translate_exception`. Imports lazily to
-        avoid a circular dependency with `errors.py`. Optional `context`
-        populates `tool` / `granularity` repair fields when the caller has them.
-        """
-        from .errors import translate_exception
-
-        return translate_exception(exc, context)
 
 
 type DatasetResult[T] = list[T] | ErrorPayload

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1009,12 +1009,6 @@ class TestErrorPayload:
         payload = ErrorPayload(error="boom")
         assert payload.error == "boom"
 
-    def test_error_payload_of_exception(self):
-        from orbnet.models import ErrorPayload
-
-        payload = ErrorPayload.of(ValueError("kaboom"))
-        assert payload.error == "kaboom"
-
     def test_error_payload_serialization(self):
         from orbnet.models import ErrorPayload
 
@@ -1387,24 +1381,3 @@ class TestExtendedErrorPayload:
 
         with pytest.raises(ValidationError):
             ErrorPayload(error="x", code="bogus_code")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-
-
-class TestErrorPayloadOfRoutesThroughTranslator:
-    """`ErrorPayload.of(exc)` must produce a structured payload for known
-    exception types (sensor_unreachable, timeout, http_error, etc.). Unknown
-    exceptions still fall through to `error=str(exc)` with `code=None`."""
-
-    def test_connect_error_emits_sensor_unreachable(self):
-        import httpx
-
-        from orbnet.models import ErrorPayload
-
-        payload = ErrorPayload.of(httpx.ConnectError("conn refused"))
-        assert payload.code == "sensor_unreachable"
-
-    def test_unknown_exception_has_no_code(self):
-        from orbnet.models import ErrorPayload
-
-        payload = ErrorPayload.of(RuntimeError("surprise"))
-        assert payload.code is None
-        assert "surprise" in payload.error


### PR DESCRIPTION
## Summary

Two small internal cleanups bundled together; both surfaced as future-work suggestions in earlier code reviews on PRs #27 and #30.

### 1. Tighten `DatasetSpec` granularity typing

`DatasetSpec.granularities` was `tuple[str, ...]` and `default_granularity` was `str | None`, even though all populated values are members of the `Granularity` literal. Tightened both to `tuple[Granularity, ...]` and `Granularity | None`. The cascade follows naturally:

- `wire_name` and `response_field` parameter types follow.
- The `plan: list[tuple[DatasetSpec, str | None]]` and `_fetch(... granularity: str | None)` in `OrbAPIClient.get_all_datasets` follow.
- The runtime-no-op `cast(Granularity | None, g)` (with its 3-line justification comment) goes away — type checker now confirms what was previously asserted by comment.

### 2. Collapse `ErrorPayload.of` duplication

After PR #27, `ErrorPayload.of(exc, ctx)` was a one-line delegation to `translate_exception(exc, ctx)`. Removed the classmethod; its only call site (`OrbAPIClient.get_all_datasets` partial-failure path) now invokes `translate_exception` directly. The `TYPE_CHECKING` import block in `models.py` (added for `of`'s `ErrorContext` annotation) is gone. Test classes that exercised the delegation are deleted — the underlying dispatch is exhaustively covered by `test_errors.py::TestTranslateExceptionDispatch`.

`ErrorPayload` is not exported from `orbnet.__init__`, so this is a purely internal change.

## Public-API impact

None. No tool signatures, no MCP wire shape, no Python-API methods change.

Independent Codex review pass on the diff before push.

## Test plan

- [x] `uv run pytest tests/ -q` — 233 pass, 100% coverage
- [x] `uv run prek run --all-files --hook-stage pre-push` — clean (ruff check, ruff format, ty check)
- [x] Independent Codex review on the diff (one false-positive flag on `cast` import — verified still load-bearing for two `cast(str, ...)` calls in property getters)

## Diffstat
```
 CHANGELOG.md           |  6 ++++++
 src/orbnet/client.py   | 14 +++++---------
 src/orbnet/datasets.py | 19 +++++++++++--------
 src/orbnet/models.py   | 21 +--------------------
 tests/test_models.py   | 27 ---------------------------
 5 files changed, 23 insertions(+), 64 deletions(-)
```

Net -41 lines.