### PR TITLE
refactor: introduce DatasetTransport seam at OrbAPIClient

### DIFF
--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -77,9 +77,14 @@ class OrbAPIClient:
                       User-Agent). Useful for identifying different applications
                       or services. If None, uses a default identifier.
             timeout: Request timeout in seconds (default: 30.0)
-            transport: Optional `DatasetTransport` for testing or alternate
-                       HTTP backends. If None, builds a default
-                       `HttpxDatasetTransport` from host/port/client_id/timeout.
+            transport: Optional `DatasetTransport` for testing. If None,
+                       builds a default `HttpxDatasetTransport` from
+                       host/port/client_id/timeout. The transport
+                       snapshots these values at construction; mutating
+                       `self.config` post-init does not alter request
+                       target, headers, or timeout. (See
+                       `orbnet.transport` for the seam's current
+                       httpx-shaped contract.)
 
         Examples:
             Connect to Orb sensor:

--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -62,6 +62,7 @@ class OrbAPIClient:
         caller_id: str | None = None,
         client_id: str | None = None,
         timeout: float = 30.0,
+        *,
         transport: DatasetTransport | None = None,
     ):
         """

--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -22,6 +22,7 @@ from .models import (
     WebResponsivenessRecord,
     WifiLinkRecord,
 )
+from .transport import DatasetTransport, HttpxDatasetTransport
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +62,7 @@ class OrbAPIClient:
         caller_id: str | None = None,
         client_id: str | None = None,
         timeout: float = 30.0,
+        transport: DatasetTransport | None = None,
     ):
         """
         Initialize the Orb API client.
@@ -75,6 +77,9 @@ class OrbAPIClient:
                       User-Agent). Useful for identifying different applications
                       or services. If None, uses a default identifier.
             timeout: Request timeout in seconds (default: 30.0)
+            transport: Optional `DatasetTransport` for testing or alternate
+                       HTTP backends. If None, builds a default
+                       `HttpxDatasetTransport` from host/port/client_id/timeout.
 
         Examples:
             Connect to Orb sensor:
@@ -104,6 +109,16 @@ class OrbAPIClient:
                 f"orbnet/{get_version('orbnet')}" if client_id is None else client_id
             ),
             timeout=timeout,
+        )
+        self._transport: DatasetTransport = (
+            transport
+            if transport is not None
+            else HttpxDatasetTransport(
+                host=self.config.host,
+                port=self.config.port,
+                client_id=cast(str, self.config.client_id),
+                timeout=self.config.timeout,
+            )
         )
 
     @property
@@ -138,40 +153,6 @@ class OrbAPIClient:
         """Construct the base URL from host and port"""
         return f"http://{self.config.host}:{self.config.port}"
 
-    def _get_headers(self) -> dict[str, str]:
-        """Get common headers for API requests"""
-        return {"Accept": "application/json", "User-Agent": self.client_id}
-
-    async def _get_dataset(
-        self,
-        dataset_name: str,
-        caller_id: str | None = None,
-        **params,
-    ) -> list[dict[str, Any]]:
-        """
-        Internal method to fetch a dataset from the Local Data API.
-
-        Args:
-            dataset_name: Name of the dataset (e.g., "responsiveness_1s")
-            caller_id: Override the default caller_id for this request
-            **params: Additional query parameters
-
-        Returns:
-            List of records as dictionaries
-        """
-        caller = caller_id or self.config.caller_id
-        endpoint = f"{self.base_url}/api/v2/datasets/{dataset_name}.json"
-
-        query_params = {"id": caller, **params}
-
-        async with httpx.AsyncClient(timeout=self.config.timeout) as client:
-            response = await client.get(
-                endpoint, headers=self._get_headers(), params=query_params
-            )
-            response.raise_for_status()
-
-            return response.json()
-
     async def _fetch(
         self,
         spec: DatasetSpec,
@@ -197,10 +178,10 @@ class OrbAPIClient:
                 f"Valid: {', '.join(spec.granularities)}"
             )
 
-        raw_data = await self._get_dataset(
+        caller = caller_id or self.config.caller_id
+        raw_data = await self._transport.fetch_dataset(
             spec.wire_name(granularity),
-            caller_id=caller_id,
-            **params,
+            {"id": caller, **params},
         )
         return [spec.record_class(**record) for record in raw_data]
 

--- a/src/orbnet/transport.py
+++ b/src/orbnet/transport.py
@@ -2,10 +2,19 @@
 
 `OrbAPIClient` does not speak HTTP directly; it composes a `DatasetTransport`
 that takes a wire-name and query params and returns the parsed JSON list.
-Production code uses `HttpxDatasetTransport`; tests use a fake.
+Production code uses `HttpxDatasetTransport`; tests use an in-memory fake.
 
-The seam exists so test code never has to mock `httpx.AsyncClient` to
-exercise client behavior. Two adapters (httpx + fake) make the seam real.
+The seam exists primarily so test code never has to mock `httpx.AsyncClient`
+to exercise client behavior. Two adapters (httpx + fake) make the seam real.
+
+Today the seam is httpx-shaped: `OrbAPIClient.poll_dataset` catches
+`httpx.HTTPError` to swallow transport errors, and `orbnet.errors`
+dispatches on httpx exception types when translating to `ErrorPayload`.
+A transport implementation that raises non-httpx exception types will
+not get the same polling/translation behavior. Introducing a
+transport-neutral error type is future work; until then, alternate
+adapters should raise `httpx.HTTPError` subclasses (or a subclass
+thereof) for transport-level failures.
 """
 
 from typing import Any, Protocol
@@ -14,7 +23,14 @@ import httpx
 
 
 class DatasetTransport(Protocol):
-    """Port for fetching raw dataset records by wire name."""
+    """Port for fetching raw dataset records by wire name.
+
+    Implementations must raise `httpx.HTTPError` subclasses for
+    transport-level failures (network errors, timeouts, non-2xx
+    responses). `OrbAPIClient.poll_dataset` and `orbnet.errors`
+    branch on httpx exception types; non-httpx errors propagate
+    instead of being recognized.
+    """
 
     async def fetch_dataset(
         self, wire_name: str, params: dict[str, Any]

--- a/src/orbnet/transport.py
+++ b/src/orbnet/transport.py
@@ -1,0 +1,51 @@
+"""Dataset-fetch transport seam.
+
+`OrbAPIClient` does not speak HTTP directly; it composes a `DatasetTransport`
+that takes a wire-name and query params and returns the parsed JSON list.
+Production code uses `HttpxDatasetTransport`; tests use a fake.
+
+The seam exists so test code never has to mock `httpx.AsyncClient` to
+exercise client behavior. Two adapters (httpx + fake) make the seam real.
+"""
+
+from typing import Any, Protocol
+
+import httpx
+
+
+class DatasetTransport(Protocol):
+    """Port for fetching raw dataset records by wire name."""
+
+    async def fetch_dataset(
+        self, wire_name: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]: ...
+
+
+class HttpxDatasetTransport:
+    """Production adapter: GET against the Orb Local Data API.
+
+    Per-call lifecycle: opens a fresh `httpx.AsyncClient` for each fetch and
+    closes it via `async with`. No long-lived client; no `aclose()` to manage.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        client_id: str,
+        timeout: float,
+    ):
+        self._host = host
+        self._port = port
+        self._client_id = client_id
+        self._timeout = timeout
+
+    async def fetch_dataset(
+        self, wire_name: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        endpoint = f"http://{self._host}:{self._port}/api/v2/datasets/{wire_name}.json"
+        headers = {"Accept": "application/json", "User-Agent": self._client_id}
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.get(endpoint, headers=headers, params=params)
+            response.raise_for_status()
+            return response.json()

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,17 +10,23 @@ tests/
 ├── conftest.py              # Pytest configuration and shared fixtures
 ├── test_models.py           # Tests for Pydantic models
 ├── test_client.py           # Tests for OrbAPIClient class
+├── test_transport.py        # Tests for HttpxDatasetTransport adapter
+├── test_datasets.py         # Tests for DatasetSpec registry
+├── test_errors.py           # Tests for ErrorPayload translator
 ├── test_mcp_server.py       # Tests for MCP server tools
 ├── test_integration.py      # Integration tests
 ├── test_utils.py            # Test utilities and helpers
-└── README.md               # This file
+└── README.md                # This file
 ```
 
 ## Test Categories
 
 ### Unit Tests
 - **test_models.py**: Tests for all Pydantic models including validation, serialization, and error handling
-- **test_client.py**: Tests for the OrbAPIClient class including HTTP requests, error handling, and async operations
+- **test_client.py**: Tests for the OrbAPIClient class including granularity validation, error handling, async operations, and the client→transport contract
+- **test_transport.py**: Tests for the `HttpxDatasetTransport` adapter (the only place httpx is mocked directly)
+- **test_datasets.py**: Tests for the `DatasetSpec` registry and poll-name aliasing
+- **test_errors.py**: Tests for the exception → `ErrorPayload` translator
 - **test_mcp_server.py**: Tests for MCP server tools and configuration
 
 ### Integration Tests
@@ -121,11 +127,8 @@ The test suite includes comprehensive fixtures in `conftest.py`:
 - `sample_all_datasets_response`: Mock response for get_all_datasets
 - `sample_error_response`: Mock error response
 
-### Mock Fixtures
-- `mock_httpx_response`: Mock httpx response object
-- `mock_httpx_client`: Mock httpx AsyncClient
-- `mock_httpx_get`: Mock httpx.AsyncClient.get method
-- `mock_httpx_client_context`: Mock httpx.AsyncClient context manager
+### Transport Test Double
+- `fake_transport`: An empty `FakeDatasetTransport` for injection into `OrbAPIClient(transport=...)`. Populate `responses[wire_name]` with either a list of records (success) or an Exception (failure); inspect `calls` to assert on what was fetched. Replaces the prior pattern of mocking `httpx.AsyncClient` directly.
 
 ### Configuration Fixtures
 - `default_client_config`: Default client configuration for testing
@@ -182,13 +185,16 @@ def test_with_fixture(sample_scores_data):
     assert len(sample_scores_data) > 0
 ```
 
-### Mocking
-Use the provided mock fixtures or create custom mocks:
+### Faking the transport
+Inject `fake_transport` into `OrbAPIClient` and stage canned responses keyed by wire name:
 ```python
-def test_with_mock(mock_httpx_response):
-    mock_httpx_response.json.return_value = {"test": "data"}
-    # Test implementation
+async def test_with_fake_transport(sample_scores_data, fake_transport):
+    fake_transport.responses["scores_1m"] = sample_scores_data
+    client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+    result = await client.get_scores_1m()
+    assert fake_transport.calls[-1][0] == "scores_1m"
 ```
+For the production HTTP adapter itself, see `test_transport.py` — that is the only place httpx is mocked directly.
 
 ## Continuous Integration
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,43 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+# ---------------------------------------------------------------------------
+# Dataset transport test double
+# ---------------------------------------------------------------------------
+
+
+class FakeDatasetTransport:
+    """In-memory `DatasetTransport` for tests.
+
+    Set `responses[wire_name]` to either a list[dict] (success) or an
+    Exception instance (raised on fetch). `calls` captures the full
+    (wire_name, params) sequence so tests can assert on what was asked for.
+    """
+
+    def __init__(self):
+        self.responses: dict[str, list[dict[str, Any]] | Exception] = {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def fetch_dataset(
+        self, wire_name: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.calls.append((wire_name, dict(params)))
+        if wire_name not in self.responses:
+            raise KeyError(
+                f"FakeDatasetTransport: no response set for {wire_name!r}. "
+                f"Set fake_transport.responses[{wire_name!r}] in your test."
+            )
+        result = self.responses[wire_name]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+@pytest.fixture
+def fake_transport():
+    """An empty `FakeDatasetTransport`; populate `responses` per-test."""
+    return FakeDatasetTransport()
+
 
 @pytest.fixture
 def sample_scores_data() -> list[dict[str, Any]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ Pytest configuration and shared fixtures for orbnet tests.
 """
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -249,41 +248,6 @@ def sample_wifi_link_data() -> list[dict[str, Any]]:
             "speed_test_engine": 0,
         }
     ]
-
-
-@pytest.fixture
-def mock_httpx_response():
-    """Mock httpx response object."""
-    response = MagicMock()
-    response.raise_for_status = MagicMock()
-    response.json = MagicMock()
-    response.text = "mock response text"
-    return response
-
-
-@pytest.fixture
-def mock_httpx_client():
-    """Mock httpx AsyncClient."""
-    client = AsyncMock()
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=None)
-    return client
-
-
-@pytest.fixture
-def mock_httpx_get(mock_httpx_client, mock_httpx_response):
-    """Mock httpx.AsyncClient.get method."""
-    mock_httpx_client.get = AsyncMock(return_value=mock_httpx_response)
-    return mock_httpx_client.get
-
-
-@pytest.fixture
-def mock_httpx_client_context(mock_httpx_client):
-    """Mock httpx.AsyncClient context manager."""
-    with MagicMock() as mock_context:
-        mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_httpx_client)
-        mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
-        return mock_context
 
 
 @pytest.fixture

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -528,6 +528,69 @@ class TestFetchHelper:
 
         assert fake_transport.calls[-1][0] == "web_responsiveness_results"
 
+    @pytest.mark.asyncio
+    async def test_fetch_threads_caller_id_override_into_params(
+        self, sample_scores_data, fake_transport
+    ):
+        """`_fetch` must pass an explicit caller_id override into the
+        transport's params dict as `id`. The deleted `_get_dataset`
+        test covered this contract; this asserts it directly at the
+        client→transport seam."""
+        from orbnet.datasets import DATASETS
+
+        fake_transport.responses["scores_1m"] = sample_scores_data
+
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        await client._fetch(DATASETS["scores"], "1m", caller_id="override-123")
+
+        params = fake_transport.calls[-1][1]
+        assert params["id"] == "override-123"
+
+    @pytest.mark.asyncio
+    async def test_fetch_uses_default_caller_id_when_no_override(
+        self, sample_scores_data, fake_transport
+    ):
+        """When no caller_id is passed, `_fetch` must thread the
+        client's configured caller_id (set in __init__) into params."""
+        from orbnet.datasets import DATASETS
+
+        fake_transport.responses["scores_1m"] = sample_scores_data
+
+        client = OrbAPIClient(
+            host="192.168.1.100",
+            caller_id="configured-default",
+            transport=fake_transport,
+        )
+        await client._fetch(DATASETS["scores"], "1m")
+
+        params = fake_transport.calls[-1][1]
+        assert params["id"] == "configured-default"
+
+    @pytest.mark.asyncio
+    async def test_fetch_passes_extra_params_to_transport(
+        self, sample_scores_data, fake_transport
+    ):
+        """`_fetch`'s `**params` must reach the transport's params dict
+        alongside `id`. The deleted `_get_dataset_with_extra_params`
+        test covered this; this asserts the same contract via the seam."""
+        from orbnet.datasets import DATASETS
+
+        fake_transport.responses["scores_1m"] = sample_scores_data
+
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        await client._fetch(
+            DATASETS["scores"],
+            "1m",
+            start_time=1700000000000,
+            end_time=1700000060000,
+        )
+
+        params = fake_transport.calls[-1][1]
+        assert params["start_time"] == 1700000000000
+        assert params["end_time"] == 1700000060000
+        # `id` is always populated alongside extra params.
+        assert "id" in params
+
 
 class TestGetAllDatasetsPlan:
     """Verify get_all_datasets dispatches to the right wire endpoints."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ Tests for OrbAPIClient in orbnet.client.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -51,226 +51,101 @@ class TestOrbAPIClient:
         client = OrbAPIClient(host="example.com", port=9000)
         assert client.base_url == "http://example.com:9000"
 
-    def test_get_headers(self):
-        """Test _get_headers method."""
-        client = OrbAPIClient(host="192.168.1.100", client_id="test-client")
-        headers = client._get_headers()
-        assert headers == {
-            "Accept": "application/json",
-            "User-Agent": "test-client",
-        }
-
-    @pytest.mark.asyncio
-    async def test_get_dataset(self, sample_scores_data, mock_httpx_response):
-        """Test _get_dataset method."""
-        mock_httpx_response.json.return_value = sample_scores_data
-
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
-
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client._get_dataset("scores_1m")
-
-            assert result == sample_scores_data
-            mock_client.get.assert_called_once()
-            call_args = mock_client.get.call_args
-            assert "scores_1m.json" in call_args[0][0]
-            assert call_args[1]["params"]["id"] == client.caller_id
-
-    @pytest.mark.asyncio
-    async def test_get_dataset_with_custom_caller_id(
-        self, sample_scores_data, mock_httpx_response
-    ):
-        """Test _get_dataset with custom caller_id."""
-        mock_httpx_response.json.return_value = sample_scores_data
-
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
-
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client._get_dataset("scores_1m", caller_id="custom-caller")
-
-            assert result == sample_scores_data
-            call_args = mock_client.get.call_args
-            assert call_args[1]["params"]["id"] == "custom-caller"
-
-    @pytest.mark.asyncio
-    async def test_get_dataset_with_extra_params(
-        self, sample_scores_data, mock_httpx_response
-    ):
-        """Test _get_dataset with extra parameters."""
-        mock_httpx_response.json.return_value = sample_scores_data
-
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
-
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client._get_dataset(
-                "scores_1m",
-                start_time=1700000000000,
-                end_time=1700000060000,
-            )
-
-            assert result == sample_scores_data
-            call_args = mock_client.get.call_args
-            params = call_args[1]["params"]
-            assert params["start_time"] == 1700000000000
-            assert params["end_time"] == 1700000060000
-
-    @pytest.mark.asyncio
-    async def test_get_dataset_http_error(self, mock_httpx_response):
-        """Test _get_dataset with HTTP error."""
-        mock_httpx_response.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "404 Not Found", request=MagicMock(), response=mock_httpx_response
-        )
-
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
-
-            client = OrbAPIClient(host="192.168.1.100")
-
-            with pytest.raises(httpx.HTTPStatusError):
-                await client._get_dataset("scores_1m")
-
     @pytest.mark.asyncio
     async def test_get_responsiveness_1m(
-        self, sample_responsiveness_data, mock_httpx_response
+        self, sample_responsiveness_data, fake_transport
     ):
         """Test get_responsiveness method with 1m granularity returns
         ResponsivenessRecord objects."""
-        mock_httpx_response.json.return_value = sample_responsiveness_data
+        fake_transport.responses["responsiveness_1m"] = sample_responsiveness_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await client.get_responsiveness(granularity="1m")
 
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_responsiveness(granularity="1m")
+        # Check result is a list of ResponsivenessRecord objects
+        assert isinstance(result, list)
+        assert len(result) == len(sample_responsiveness_data)
+        assert all(isinstance(r, ResponsivenessRecord) for r in result)
 
-            # Check result is a list of ResponsivenessRecord objects
-            assert isinstance(result, list)
-            assert len(result) == len(sample_responsiveness_data)
-            assert all(isinstance(r, ResponsivenessRecord) for r in result)
+        # Check data integrity
+        assert result[0].orb_id == sample_responsiveness_data[0]["orb_id"]
+        assert result[0].lag_avg_us == sample_responsiveness_data[0]["lag_avg_us"]
+        assert (
+            result[0].packet_loss_pct
+            == sample_responsiveness_data[0]["packet_loss_pct"]
+        )
 
-            # Check data integrity
-            assert result[0].orb_id == sample_responsiveness_data[0]["orb_id"]
-            assert result[0].lag_avg_us == sample_responsiveness_data[0]["lag_avg_us"]
-            assert (
-                result[0].packet_loss_pct
-                == sample_responsiveness_data[0]["packet_loss_pct"]
-            )
-
-            call_args = mock_client.get.call_args
-            assert "responsiveness_1m.json" in call_args[0][0]
+        assert fake_transport.calls[-1][0] == "responsiveness_1m"
 
     @pytest.mark.asyncio
     async def test_get_responsiveness_1s(
-        self, sample_responsiveness_data, mock_httpx_response
+        self, sample_responsiveness_data, fake_transport
     ):
         """Test get_responsiveness method with 1s granularity."""
-        mock_httpx_response.json.return_value = sample_responsiveness_data
+        fake_transport.responses["responsiveness_1s"] = sample_responsiveness_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await client.get_responsiveness(granularity="1s")
 
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_responsiveness(granularity="1s")
-
-            assert isinstance(result, list)
-            assert all(isinstance(r, ResponsivenessRecord) for r in result)
-            call_args = mock_client.get.call_args
-            assert "responsiveness_1s.json" in call_args[0][0]
+        assert isinstance(result, list)
+        assert all(isinstance(r, ResponsivenessRecord) for r in result)
+        assert fake_transport.calls[-1][0] == "responsiveness_1s"
 
     @pytest.mark.asyncio
     async def test_get_responsiveness_15s(
-        self, sample_responsiveness_data, mock_httpx_response
+        self, sample_responsiveness_data, fake_transport
     ):
         """Test get_responsiveness method with 15s granularity."""
-        mock_httpx_response.json.return_value = sample_responsiveness_data
+        fake_transport.responses["responsiveness_15s"] = sample_responsiveness_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await client.get_responsiveness(granularity="15s")
 
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_responsiveness(granularity="15s")
-
-            assert isinstance(result, list)
-            assert all(isinstance(r, ResponsivenessRecord) for r in result)
-            call_args = mock_client.get.call_args
-            assert "responsiveness_15s.json" in call_args[0][0]
+        assert isinstance(result, list)
+        assert all(isinstance(r, ResponsivenessRecord) for r in result)
+        assert fake_transport.calls[-1][0] == "responsiveness_15s"
 
     @pytest.mark.asyncio
-    async def test_get_wifi_link_1m(self, sample_wifi_link_data, mock_httpx_response):
+    async def test_get_wifi_link_1m(self, sample_wifi_link_data, fake_transport):
         """Test get_wifi_link with 1m granularity returns WifiLinkRecord objects."""
-        mock_httpx_response.json.return_value = sample_wifi_link_data
+        fake_transport.responses["wifi_link_1m"] = sample_wifi_link_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await client.get_wifi_link(granularity="1m")
 
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_wifi_link(granularity="1m")
+        assert isinstance(result, list)
+        assert len(result) == len(sample_wifi_link_data)
+        assert all(isinstance(r, WifiLinkRecord) for r in result)
 
-            assert isinstance(result, list)
-            assert len(result) == len(sample_wifi_link_data)
-            assert all(isinstance(r, WifiLinkRecord) for r in result)
+        assert result[0].orb_id == sample_wifi_link_data[0]["orb_id"]
+        assert result[0].rssi_avg == sample_wifi_link_data[0]["rssi_avg"]
+        assert result[0].channel_band == sample_wifi_link_data[0]["channel_band"]
 
-            assert result[0].orb_id == sample_wifi_link_data[0]["orb_id"]
-            assert result[0].rssi_avg == sample_wifi_link_data[0]["rssi_avg"]
-            assert result[0].channel_band == sample_wifi_link_data[0]["channel_band"]
-
-            call_args = mock_client.get.call_args
-            assert "wifi_link_1m.json" in call_args[0][0]
+        assert fake_transport.calls[-1][0] == "wifi_link_1m"
 
     @pytest.mark.asyncio
-    async def test_get_wifi_link_1s(self, sample_wifi_link_data, mock_httpx_response):
+    async def test_get_wifi_link_1s(self, sample_wifi_link_data, fake_transport):
         """Test get_wifi_link method with 1s granularity."""
-        mock_httpx_response.json.return_value = sample_wifi_link_data
+        fake_transport.responses["wifi_link_1s"] = sample_wifi_link_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await client.get_wifi_link(granularity="1s")
 
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_wifi_link(granularity="1s")
-
-            assert isinstance(result, list)
-            assert all(isinstance(r, WifiLinkRecord) for r in result)
-            call_args = mock_client.get.call_args
-            assert "wifi_link_1s.json" in call_args[0][0]
+        assert isinstance(result, list)
+        assert all(isinstance(r, WifiLinkRecord) for r in result)
+        assert fake_transport.calls[-1][0] == "wifi_link_1s"
 
     @pytest.mark.asyncio
-    async def test_get_wifi_link_15s(self, sample_wifi_link_data, mock_httpx_response):
+    async def test_get_wifi_link_15s(self, sample_wifi_link_data, fake_transport):
         """Test get_wifi_link method with 15s granularity."""
-        mock_httpx_response.json.return_value = sample_wifi_link_data
+        fake_transport.responses["wifi_link_15s"] = sample_wifi_link_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await client.get_wifi_link(granularity="15s")
 
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_wifi_link(granularity="15s")
-
-            assert isinstance(result, list)
-            assert all(isinstance(r, WifiLinkRecord) for r in result)
-            call_args = mock_client.get.call_args
-            assert "wifi_link_15s.json" in call_args[0][0]
+        assert isinstance(result, list)
+        assert all(isinstance(r, WifiLinkRecord) for r in result)
+        assert fake_transport.calls[-1][0] == "wifi_link_15s"
 
     @pytest.mark.asyncio
     async def test_get_all_datasets_basic(
@@ -280,6 +155,7 @@ class TestOrbAPIClient:
         sample_web_responsiveness_data,
         sample_speed_data,
         sample_wifi_link_data,
+        fake_transport,
     ):
         """Test get_all_datasets method returns AllDatasetsResponse."""
         responses = {
@@ -290,34 +166,30 @@ class TestOrbAPIClient:
             "wifi_link_1m": sample_wifi_link_data,
         }
 
-        async def fake_get_dataset(self, dataset_name, caller_id=None, **params):
-            return responses[dataset_name]
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        fake_transport.responses.update(responses)
+        result = await client.get_all_datasets()
 
-        with patch.object(OrbAPIClient, "_get_dataset", new=fake_get_dataset):
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_all_datasets()
+        # Check result is AllDatasetsResponse
+        assert isinstance(result, AllDatasetsResponse)
 
-            # Check result is AllDatasetsResponse
-            assert isinstance(result, AllDatasetsResponse)
+        # Check all required datasets are present
+        assert isinstance(result.scores_1m, list)
+        assert isinstance(result.responsiveness_1m, list)
+        assert isinstance(result.web_responsiveness, list)
+        assert isinstance(result.speed_results, list)
+        assert isinstance(result.wifi_link_1m, list)
 
-            # Check all required datasets are present
-            assert isinstance(result.scores_1m, list)
-            assert isinstance(result.responsiveness_1m, list)
-            assert isinstance(result.web_responsiveness, list)
-            assert isinstance(result.speed_results, list)
-            assert isinstance(result.wifi_link_1m, list)
-
-            # Check data types
-            assert all(isinstance(r, ScoreRecord) for r in result.scores_1m)
-            assert all(
-                isinstance(r, ResponsivenessRecord) for r in result.responsiveness_1m
-            )
-            assert all(
-                isinstance(r, WebResponsivenessRecord)
-                for r in result.web_responsiveness
-            )
-            assert all(isinstance(r, SpeedRecord) for r in result.speed_results)
-            assert all(isinstance(r, WifiLinkRecord) for r in result.wifi_link_1m)
+        # Check data types
+        assert all(isinstance(r, ScoreRecord) for r in result.scores_1m)
+        assert all(
+            isinstance(r, ResponsivenessRecord) for r in result.responsiveness_1m
+        )
+        assert all(
+            isinstance(r, WebResponsivenessRecord) for r in result.web_responsiveness
+        )
+        assert all(isinstance(r, SpeedRecord) for r in result.speed_results)
+        assert all(isinstance(r, WifiLinkRecord) for r in result.wifi_link_1m)
 
     @pytest.mark.asyncio
     async def test_get_all_datasets_with_all_wifi_link(
@@ -327,6 +199,7 @@ class TestOrbAPIClient:
         sample_web_responsiveness_data,
         sample_speed_data,
         sample_wifi_link_data,
+        fake_transport,
     ):
         """Test get_all_datasets method with all Wi-Fi Link granularities."""
         responses = {
@@ -339,18 +212,15 @@ class TestOrbAPIClient:
             "wifi_link_1s": sample_wifi_link_data,
         }
 
-        async def fake_get_dataset(self, dataset_name, caller_id=None, **params):
-            return responses[dataset_name]
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        fake_transport.responses.update(responses)
+        result = await client.get_all_datasets(include_all_wifi_link=True)
 
-        with patch.object(OrbAPIClient, "_get_dataset", new=fake_get_dataset):
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_all_datasets(include_all_wifi_link=True)
-
-            assert isinstance(result, AllDatasetsResponse)
-            assert isinstance(result.wifi_link_1m, list)
-            assert isinstance(result.wifi_link_15s, list)
-            assert isinstance(result.wifi_link_1s, list)
-            assert all(isinstance(r, WifiLinkRecord) for r in result.wifi_link_1m)
+        assert isinstance(result, AllDatasetsResponse)
+        assert isinstance(result.wifi_link_1m, list)
+        assert isinstance(result.wifi_link_15s, list)
+        assert isinstance(result.wifi_link_1s, list)
+        assert all(isinstance(r, WifiLinkRecord) for r in result.wifi_link_1m)
 
     @pytest.mark.asyncio
     async def test_get_all_datasets_with_all_responsiveness(
@@ -360,6 +230,7 @@ class TestOrbAPIClient:
         sample_web_responsiveness_data,
         sample_speed_data,
         sample_wifi_link_data,
+        fake_transport,
     ):
         """Test get_all_datasets method with all responsiveness granularities."""
         responses = {
@@ -372,20 +243,17 @@ class TestOrbAPIClient:
             "wifi_link_1m": sample_wifi_link_data,
         }
 
-        async def fake_get_dataset(self, dataset_name, caller_id=None, **params):
-            return responses[dataset_name]
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        fake_transport.responses.update(responses)
+        result = await client.get_all_datasets(include_all_responsiveness=True)
 
-        with patch.object(OrbAPIClient, "_get_dataset", new=fake_get_dataset):
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_all_datasets(include_all_responsiveness=True)
-
-            assert isinstance(result, AllDatasetsResponse)
-            assert isinstance(result.scores_1m, list)
-            assert isinstance(result.responsiveness_1m, list)
-            assert isinstance(result.responsiveness_15s, list)
-            assert isinstance(result.responsiveness_1s, list)
-            assert isinstance(result.web_responsiveness, list)
-            assert isinstance(result.speed_results, list)
+        assert isinstance(result, AllDatasetsResponse)
+        assert isinstance(result.scores_1m, list)
+        assert isinstance(result.responsiveness_1m, list)
+        assert isinstance(result.responsiveness_15s, list)
+        assert isinstance(result.responsiveness_1s, list)
+        assert isinstance(result.web_responsiveness, list)
+        assert isinstance(result.speed_results, list)
 
     @pytest.mark.asyncio
     async def test_get_all_datasets_with_error(
@@ -394,6 +262,7 @@ class TestOrbAPIClient:
         sample_web_responsiveness_data,
         sample_speed_data,
         sample_wifi_link_data,
+        fake_transport,
     ):
         """Test get_all_datasets method with one dataset failing."""
         from orbnet.models import ErrorPayload
@@ -405,121 +274,100 @@ class TestOrbAPIClient:
             "wifi_link_1m": sample_wifi_link_data,
         }
 
-        async def fake_get_dataset(self, dataset_name, caller_id=None, **params):
-            if dataset_name == "responsiveness_1m":
-                raise Exception("Connection error")
-            return responses[dataset_name]
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        fake_transport.responses.update(responses)
+        fake_transport.responses["responsiveness_1m"] = Exception("Connection error")
+        result = await client.get_all_datasets()
 
-        with patch.object(OrbAPIClient, "_get_dataset", new=fake_get_dataset):
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_all_datasets()
-
-            assert isinstance(result, AllDatasetsResponse)
-            assert isinstance(result.scores_1m, list)
-            assert isinstance(result.responsiveness_1m, ErrorPayload)
-            assert result.responsiveness_1m.error == "Connection error"
-            assert isinstance(result.web_responsiveness, list)
-            assert isinstance(result.speed_results, list)
+        assert isinstance(result, AllDatasetsResponse)
+        assert isinstance(result.scores_1m, list)
+        assert isinstance(result.responsiveness_1m, ErrorPayload)
+        assert result.responsiveness_1m.error == "Connection error"
+        assert isinstance(result.web_responsiveness, list)
+        assert isinstance(result.speed_results, list)
 
     @pytest.mark.asyncio
-    async def test_poll_dataset_success(self, sample_scores_data, mock_httpx_response):
+    async def test_poll_dataset_success(self, sample_scores_data, fake_transport):
         """Test poll_dataset method with successful polling returns Pydantic objects."""
-        mock_httpx_response.json.return_value = sample_scores_data
+        fake_transport.responses["scores_1m"] = sample_scores_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
+        # Test with max_iterations=2
+        results = []
+        async for records in client.poll_dataset(
+            "scores_1m", interval=0.01, max_iterations=2
+        ):
+            results.append(records)
 
-            # Test with max_iterations=2
-            results = []
-            async for records in client.poll_dataset(
-                "scores_1m", interval=0.01, max_iterations=2
-            ):
-                results.append(records)
-
-            assert len(results) == 2
-            # Check all results are lists of ScoreRecord objects
-            assert all(isinstance(r, list) for r in results)
-            assert all(isinstance(rec, ScoreRecord) for r in results for rec in r)
+        assert len(results) == 2
+        # Check all results are lists of ScoreRecord objects
+        assert all(isinstance(r, list) for r in results)
+        assert all(isinstance(rec, ScoreRecord) for r in results for rec in r)
 
     @pytest.mark.asyncio
-    async def test_poll_dataset_with_callback(
-        self, sample_scores_data, mock_httpx_response
-    ):
+    async def test_poll_dataset_with_callback(self, sample_scores_data, fake_transport):
         """Test poll_dataset method with callback function."""
-        mock_httpx_response.json.return_value = sample_scores_data
+        fake_transport.responses["scores_1m"] = sample_scores_data
         callback_calls = []
 
         def test_callback(dataset_name, records):
             callback_calls.append((dataset_name, records))
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
+        # Test with max_iterations=1
+        results = []
+        async for records in client.poll_dataset(
+            "scores_1m", interval=0.01, max_iterations=1, callback=test_callback
+        ):
+            results.append(records)
 
-            # Test with max_iterations=1
-            results = []
-            async for records in client.poll_dataset(
-                "scores_1m", interval=0.01, max_iterations=1, callback=test_callback
-            ):
-                results.append(records)
-
-            assert len(results) == 1
-            assert len(callback_calls) == 1
-            assert callback_calls[0][0] == "scores_1m"
-            # Check callback received Pydantic objects
-            assert all(isinstance(r, ScoreRecord) for r in callback_calls[0][1])
+        assert len(results) == 1
+        assert len(callback_calls) == 1
+        assert callback_calls[0][0] == "scores_1m"
+        # Check callback received Pydantic objects
+        assert all(isinstance(r, ScoreRecord) for r in callback_calls[0][1])
 
     @pytest.mark.asyncio
     async def test_poll_dataset_with_async_callback(
-        self, sample_scores_data, mock_httpx_response
+        self, sample_scores_data, fake_transport
     ):
         """Test poll_dataset method with async callback function."""
-        mock_httpx_response.json.return_value = sample_scores_data
+        fake_transport.responses["scores_1m"] = sample_scores_data
         callback_calls = []
 
         async def test_async_callback(dataset_name, records):
             callback_calls.append((dataset_name, records))
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
+        # Test with max_iterations=1
+        results = []
+        async for records in client.poll_dataset(
+            "scores_1m",
+            interval=0.01,
+            max_iterations=1,
+            callback=test_async_callback,
+        ):
+            results.append(records)
 
-            # Test with max_iterations=1
-            results = []
-            async for records in client.poll_dataset(
-                "scores_1m",
-                interval=0.01,
-                max_iterations=1,
-                callback=test_async_callback,
-            ):
-                results.append(records)
-
-            assert len(results) == 1
-            assert len(callback_calls) == 1
-            assert callback_calls[0][0] == "scores_1m"
-            # Check callback received Pydantic objects
-            assert all(isinstance(r, ScoreRecord) for r in callback_calls[0][1])
+        assert len(results) == 1
+        assert len(callback_calls) == 1
+        assert callback_calls[0][0] == "scores_1m"
+        # Check callback received Pydantic objects
+        assert all(isinstance(r, ScoreRecord) for r in callback_calls[0][1])
 
     @pytest.mark.asyncio
     async def test_poll_dataset_awaits_partial_of_async_callback(
-        self, sample_scores_data, mock_httpx_response
+        self, sample_scores_data, fake_transport
     ):
         """`functools.partial(async_fn, ...)` returns a coroutine when called.
         The dispatch must await it regardless of how `partial` is classified
         by `asyncio.iscoroutinefunction` (which varies by Python version)."""
         import functools
 
-        mock_httpx_response.json.return_value = sample_scores_data
+        fake_transport.responses["scores_1m"] = sample_scores_data
         observed = []
 
         async def async_fn(prefix, dataset_name, records):
@@ -527,30 +375,25 @@ class TestOrbAPIClient:
 
         partial_callback = functools.partial(async_fn, "tag")
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
-
-            async for _ in client.poll_dataset(
-                "scores_1m",
-                interval=0.01,
-                max_iterations=1,
-                callback=partial_callback,
-            ):
-                pass
+        async for _ in client.poll_dataset(
+            "scores_1m",
+            interval=0.01,
+            max_iterations=1,
+            callback=partial_callback,
+        ):
+            pass
 
         assert observed == [("tag", "scores_1m", len(sample_scores_data))]
 
     @pytest.mark.asyncio
     async def test_poll_dataset_awaits_sync_callable_returning_coroutine(
-        self, sample_scores_data, mock_httpx_response
+        self, sample_scores_data, fake_transport
     ):
         """A sync function that builds and returns a coroutine should also
         have that coroutine awaited (covers async-lambda-like patterns)."""
-        mock_httpx_response.json.return_value = sample_scores_data
+        fake_transport.responses["scores_1m"] = sample_scores_data
         observed = []
 
         async def _record(dataset_name, records):
@@ -564,55 +407,45 @@ class TestOrbAPIClient:
         # returned coroutine would be silently dropped.
         assert not asyncio.iscoroutinefunction(sync_returning_coro)
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
-
-            async for _ in client.poll_dataset(
-                "scores_1m",
-                interval=0.01,
-                max_iterations=1,
-                callback=sync_returning_coro,
-            ):
-                pass
+        async for _ in client.poll_dataset(
+            "scores_1m",
+            interval=0.01,
+            max_iterations=1,
+            callback=sync_returning_coro,
+        ):
+            pass
 
         assert observed == [("scores_1m", len(sample_scores_data))]
 
     @pytest.mark.asyncio
-    async def test_poll_dataset_with_error(self, mock_httpx_response, caplog):
+    async def test_poll_dataset_with_error(self, fake_transport, caplog):
         """Test poll_dataset method with HTTP error."""
         import logging
 
-        mock_httpx_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        fake_transport.responses["scores_1m"] = httpx.HTTPStatusError(
             "500 Internal Server Error",
             request=MagicMock(),
-            response=mock_httpx_response,
+            response=MagicMock(),
         )
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
+        # Test with max_iterations=1 - should handle error gracefully
+        results = []
+        with caplog.at_level(logging.WARNING, logger="orbnet.client"):
+            async for records in client.poll_dataset(
+                "scores_1m", interval=0.01, max_iterations=1
+            ):
+                results.append(records)
 
-            # Test with max_iterations=1 - should handle error gracefully
-            results = []
-            with caplog.at_level(logging.WARNING, logger="orbnet.client"):
-                async for records in client.poll_dataset(
-                    "scores_1m", interval=0.01, max_iterations=1
-                ):
-                    results.append(records)
-
-            # When an error occurs, the generator doesn't yield anything
-            # The error is logged but no results are yielded
-            assert len(results) == 0
-            assert len(caplog.records) == 1
-            assert caplog.records[0].levelno == logging.WARNING
-            assert "scores_1m" in caplog.records[0].message
+        # When an error occurs, the generator doesn't yield anything
+        # The error is logged but no results are yielded
+        assert len(results) == 0
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.WARNING
+        assert "scores_1m" in caplog.records[0].message
 
     @pytest.mark.asyncio
     async def test_poll_dataset_invalid_dataset_name(self):
@@ -626,32 +459,27 @@ class TestOrbAPIClient:
                 pass
 
     @pytest.mark.asyncio
-    async def test_poll_dataset_infinite(self, sample_scores_data, mock_httpx_response):
+    async def test_poll_dataset_infinite(self, sample_scores_data, fake_transport):
         """Test poll_dataset method with infinite polling (max_iterations=None)."""
-        mock_httpx_response.json.return_value = sample_scores_data
+        fake_transport.responses["scores_1m"] = sample_scores_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
+        # Test with max_iterations=None and short interval
+        # We'll manually break after a few iterations
+        results = []
+        count = 0
+        async for records in client.poll_dataset(
+            "scores_1m", interval=0.01, max_iterations=None
+        ):
+            results.append(records)
+            count += 1
+            if count >= 3:  # Break after 3 iterations
+                break
 
-            # Test with max_iterations=None and short interval
-            # We'll manually break after a few iterations
-            results = []
-            count = 0
-            async for records in client.poll_dataset(
-                "scores_1m", interval=0.01, max_iterations=None
-            ):
-                results.append(records)
-                count += 1
-                if count >= 3:  # Break after 3 iterations
-                    break
-
-            assert len(results) == 3
-            assert all(isinstance(r, list) for r in results)
-            assert all(isinstance(rec, ScoreRecord) for r in results for rec in r)
+        assert len(results) == 3
+        assert all(isinstance(r, list) for r in results)
+        assert all(isinstance(rec, ScoreRecord) for r in results for rec in r)
 
 
 class TestFetchHelper:
@@ -659,64 +487,46 @@ class TestFetchHelper:
 
     @pytest.mark.asyncio
     async def test_fetch_passes_wire_name_and_maps_records(
-        self, sample_scores_data, mock_httpx_response
+        self, sample_scores_data, fake_transport
     ):
         from orbnet.datasets import DATASETS
 
-        mock_httpx_response.json.return_value = sample_scores_data
+        fake_transport.responses["scores_1m"] = sample_scores_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await client._fetch(DATASETS["scores"], "1m")
 
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client._fetch(DATASETS["scores"], "1m")
-
-            assert mock_client.get.called
-            url = mock_client.get.call_args[0][0]
-            assert "scores_1m.json" in url
-
-            assert all(isinstance(r, ScoreRecord) for r in result)
-            assert len(result) == len(sample_scores_data)
+        assert fake_transport.calls[-1][0] == "scores_1m"
+        assert all(isinstance(r, ScoreRecord) for r in result)
+        assert len(result) == len(sample_scores_data)
 
     @pytest.mark.asyncio
     async def test_fetch_uses_default_granularity_when_omitted(
-        self, sample_responsiveness_data, mock_httpx_response
+        self, sample_responsiveness_data, fake_transport
     ):
         from orbnet.datasets import DATASETS
 
-        mock_httpx_response.json.return_value = sample_responsiveness_data
+        fake_transport.responses["responsiveness_1m"] = sample_responsiveness_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        await client._fetch(DATASETS["responsiveness"])
 
-            client = OrbAPIClient(host="192.168.1.100")
-            await client._fetch(DATASETS["responsiveness"])
-
-            url = mock_client.get.call_args[0][0]
-            assert "responsiveness_1m.json" in url
+        assert fake_transport.calls[-1][0] == "responsiveness_1m"
 
     @pytest.mark.asyncio
     async def test_fetch_honors_wire_name_override(
-        self, sample_web_responsiveness_data, mock_httpx_response
+        self, sample_web_responsiveness_data, fake_transport
     ):
         from orbnet.datasets import DATASETS
 
-        mock_httpx_response.json.return_value = sample_web_responsiveness_data
+        fake_transport.responses["web_responsiveness_results"] = (
+            sample_web_responsiveness_data
+        )
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        await client._fetch(DATASETS["web_responsiveness"])
 
-            client = OrbAPIClient(host="192.168.1.100")
-            await client._fetch(DATASETS["web_responsiveness"])
-
-            url = mock_client.get.call_args[0][0]
-            assert "web_responsiveness_results.json" in url
+        assert fake_transport.calls[-1][0] == "web_responsiveness_results"
 
 
 class TestGetAllDatasetsPlan:
@@ -730,6 +540,7 @@ class TestGetAllDatasetsPlan:
         sample_web_responsiveness_data,
         sample_speed_data,
         sample_wifi_link_data,
+        fake_transport,
     ):
         # Map dataset wire-name -> raw response.
         responses = {
@@ -742,18 +553,15 @@ class TestGetAllDatasetsPlan:
             "wifi_link_1s": sample_wifi_link_data,
         }
 
-        async def fake_get_dataset(self, dataset_name, caller_id=None, **params):
-            return responses[dataset_name]
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        fake_transport.responses.update(responses)
+        result = await client.get_all_datasets(default_granularity="1s")
 
-        with patch.object(OrbAPIClient, "_get_dataset", new=fake_get_dataset):
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_all_datasets(default_granularity="1s")
-
-            assert isinstance(result.scores_1m, list) and len(result.scores_1m) > 0
-            assert isinstance(result.responsiveness_1s, list)
-            assert isinstance(result.wifi_link_1s, list)
-            assert result.responsiveness_1m is None
-            assert result.wifi_link_1m is None
+        assert isinstance(result.scores_1m, list) and len(result.scores_1m) > 0
+        assert isinstance(result.responsiveness_1s, list)
+        assert isinstance(result.wifi_link_1s, list)
+        assert result.responsiveness_1m is None
+        assert result.wifi_link_1m is None
 
     @pytest.mark.asyncio
     async def test_include_all_responsiveness_fetches_all_three(
@@ -763,6 +571,7 @@ class TestGetAllDatasetsPlan:
         sample_web_responsiveness_data,
         sample_speed_data,
         sample_wifi_link_data,
+        fake_transport,
     ):
         responses = {
             "scores_1m": sample_scores_data,
@@ -774,18 +583,15 @@ class TestGetAllDatasetsPlan:
             "wifi_link_1m": sample_wifi_link_data,
         }
 
-        async def fake_get_dataset(self, dataset_name, caller_id=None, **params):
-            return responses[dataset_name]
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        fake_transport.responses.update(responses)
+        result = await client.get_all_datasets(include_all_responsiveness=True)
 
-        with patch.object(OrbAPIClient, "_get_dataset", new=fake_get_dataset):
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await client.get_all_datasets(include_all_responsiveness=True)
-
-            assert isinstance(result.responsiveness_1s, list)
-            assert isinstance(result.responsiveness_15s, list)
-            assert isinstance(result.responsiveness_1m, list)
-            assert result.wifi_link_15s is None
-            assert result.wifi_link_1s is None
+        assert isinstance(result.responsiveness_1s, list)
+        assert isinstance(result.responsiveness_15s, list)
+        assert isinstance(result.responsiveness_1m, list)
+        assert result.wifi_link_15s is None
+        assert result.wifi_link_1s is None
 
     @pytest.mark.asyncio
     async def test_invalid_default_granularity_raises(self):
@@ -805,28 +611,25 @@ class TestPollDatasetCallbackContract:
 
     @pytest.mark.asyncio
     async def test_callback_receives_wire_alias_verbatim(
-        self, sample_web_responsiveness_data, mock_httpx_response
+        self, sample_web_responsiveness_data, fake_transport
     ):
-        mock_httpx_response.json.return_value = sample_web_responsiveness_data
+        fake_transport.responses["web_responsiveness_results"] = (
+            sample_web_responsiveness_data
+        )
 
         captured: list[str] = []
 
         def callback(dataset_name, records):
             captured.append(dataset_name)
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
-
-            client = OrbAPIClient(host="192.168.1.100")
-            async for _ in client.poll_dataset(
-                "web_responsiveness_results",
-                interval=0.01,
-                callback=callback,
-                max_iterations=1,
-            ):
-                pass
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        async for _ in client.poll_dataset(
+            "web_responsiveness_results",
+            interval=0.01,
+            callback=callback,
+            max_iterations=1,
+        ):
+            pass
 
         assert captured == ["web_responsiveness_results"]
 
@@ -864,29 +667,22 @@ class TestPublicMethodsParametrized:
         sample_fixture,
         record_class,
         request,
-        mock_httpx_response,
+        fake_transport,
     ):
         from orbnet import models as models_module
         from orbnet.datasets import DATASETS
 
         sample_data = request.getfixturevalue(sample_fixture)
         record_cls = getattr(models_module, record_class)
-        mock_httpx_response.json.return_value = sample_data
+        ds = DATASETS[family]
+        fake_transport.responses[ds.wire_name(ds.default_granularity)] = sample_data
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await getattr(client, method_name)()
 
-            client = OrbAPIClient(host="192.168.1.100")
-            result = await getattr(client, method_name)()
-
-            assert all(isinstance(r, record_cls) for r in result)
-            assert len(result) == len(sample_data)
-
-            url = mock_client.get.call_args[0][0]
-            ds = DATASETS[family]
-            assert ds.wire_name(ds.default_granularity) in url
+        assert all(isinstance(r, record_cls) for r in result)
+        assert len(result) == len(sample_data)
+        assert fake_transport.calls[-1][0] == ds.wire_name(ds.default_granularity)
 
 
 class TestExplicitOverrideSemantics:
@@ -933,51 +729,39 @@ class TestPollDatasetPropagatesProgrammingErrors:
     the caller can surface them, instead of polling forever silently."""
 
     @pytest.mark.asyncio
-    async def test_validation_error_propagates(self, mock_httpx_response):
+    async def test_validation_error_propagates(self, fake_transport):
         """A malformed API response should raise ValidationError, not be swallowed."""
         from pydantic import ValidationError
 
         # Return data missing required fields → pydantic ValidationError
-        mock_httpx_response.json.return_value = [{"orb_id": "x"}]
+        fake_transport.responses["scores_1m"] = [{"orb_id": "x"}]
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
-
-            with pytest.raises(ValidationError):
-                async for _ in client.poll_dataset(
-                    "scores_1m", interval=0.01, max_iterations=1
-                ):
-                    pass
+        with pytest.raises(ValidationError):
+            async for _ in client.poll_dataset(
+                "scores_1m", interval=0.01, max_iterations=1
+            ):
+                pass
 
     @pytest.mark.asyncio
-    async def test_callback_error_propagates(
-        self, sample_scores_data, mock_httpx_response
-    ):
+    async def test_callback_error_propagates(self, sample_scores_data, fake_transport):
         """A buggy callback should propagate, not be silenced."""
-        mock_httpx_response.json.return_value = sample_scores_data
+        fake_transport.responses["scores_1m"] = sample_scores_data
 
         def buggy_callback(dataset_name, records):
             raise RuntimeError("callback bug")
 
-        with patch("httpx.AsyncClient") as mock_client_class:
-            mock_client = AsyncMock()
-            mock_client_class.return_value.__aenter__.return_value = mock_client
-            mock_client.get.return_value = mock_httpx_response
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
 
-            client = OrbAPIClient(host="192.168.1.100")
-
-            with pytest.raises(RuntimeError, match="callback bug"):
-                async for _ in client.poll_dataset(
-                    "scores_1m",
-                    interval=0.01,
-                    callback=buggy_callback,
-                    max_iterations=1,
-                ):
-                    pass
+        with pytest.raises(RuntimeError, match="callback bug"):
+            async for _ in client.poll_dataset(
+                "scores_1m",
+                interval=0.01,
+                callback=buggy_callback,
+                max_iterations=1,
+            ):
+                pass
 
 
 class TestGranularityValidation:
@@ -1012,25 +796,30 @@ class TestGetAllDatasetsErrorContext:
     translate_exception, with `tool` and `granularity` populated from the
     plan loop."""
 
-    async def test_partial_404_includes_repair_arguments(self, mocker):
-        import httpx
-
-        from orbnet.client import OrbAPIClient
+    async def test_partial_404_includes_repair_arguments(self, fake_transport):
         from orbnet.models import ErrorPayload
 
-        client = OrbAPIClient(host="h")
         request = httpx.Request(
             "GET", "http://h:7080/api/v2/datasets/responsiveness_1s.json"
         )
         response = httpx.Response(404, request=request)
+        fake_transport.responses["responsiveness_1s"] = httpx.HTTPStatusError(
+            "404",
+            request=request,
+            response=response,
+        )
+        # Other datasets succeed with empty lists.
+        for wire_name in (
+            "scores_1m",
+            "responsiveness_15s",
+            "responsiveness_1m",
+            "web_responsiveness_results",
+            "speed_results",
+            "wifi_link_1m",
+        ):
+            fake_transport.responses[wire_name] = []
 
-        async def fake_fetch(spec, granularity, caller_id, **kwargs):
-            if spec.family == "responsiveness" and granularity == "1s":
-                raise httpx.HTTPStatusError("404", request=request, response=response)
-            return []
-
-        mocker.patch.object(client, "_fetch", side_effect=fake_fetch)
-
+        client = OrbAPIClient(host="h", transport=fake_transport)
         result = await client.get_all_datasets(include_all_responsiveness=True)
 
         partial = result.responsiveness_1s

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,15 +44,6 @@ class TestIntegration:
         assert info["timeout"] == 45.0
         assert info["base_url"] == "http://test-host:8080"
 
-    @pytest.mark.asyncio
-    async def test_client_headers_integration(self):
-        """Test that client headers are properly constructed."""
-        client = OrbAPIClient(host="192.168.1.100", client_id="test-client")
-        headers = client._get_headers()
-
-        expected_headers = {"Accept": "application/json", "User-Agent": "test-client"}
-        assert headers == expected_headers
-
     def test_model_validation_integration(self):
         """Test that models work together in realistic scenarios."""
         from orbnet.models import (

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -136,3 +136,27 @@ class TestHttpxDatasetTransport:
 
             init_kwargs = mock_client_class.call_args[1]
             assert init_kwargs["timeout"] == 12.5
+
+    @pytest.mark.asyncio
+    async def test_fetch_constructs_a_fresh_client_per_call(self, mock_httpx_response):
+        """Per-call lifecycle: each fetch_dataset call must open and
+        close its own httpx.AsyncClient via `async with`. Regressing
+        to a long-lived client would change connection-pool semantics
+        and silently alter timeout-per-call behavior."""
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_httpx_response
+
+            transport = HttpxDatasetTransport(
+                host="h",
+                port=7080,
+                client_id="ua",
+                timeout=30.0,
+            )
+            await transport.fetch_dataset("scores_1m", {"id": "x"})
+            await transport.fetch_dataset("scores_1m", {"id": "x"})
+
+            assert mock_client_class.call_count == 2
+            # Each construction is followed by a context-manager exit.
+            assert mock_client_class.return_value.__aexit__.await_count == 2

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,138 @@
+"""Tests for orbnet.transport — the HTTP adapter at the dataset-fetch seam.
+
+These are the only tests that mock httpx directly. Everywhere else in the
+suite, OrbAPIClient is constructed with a FakeDatasetTransport instead.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from orbnet.transport import HttpxDatasetTransport
+
+
+@pytest.fixture
+def mock_httpx_response():
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value=[])
+    return response
+
+
+class TestHttpxDatasetTransport:
+    @pytest.mark.asyncio
+    async def test_fetch_builds_correct_url(self, mock_httpx_response):
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_httpx_response
+
+            transport = HttpxDatasetTransport(
+                host="192.168.1.100",
+                port=7080,
+                client_id="orbnet/test",
+                timeout=30.0,
+            )
+            await transport.fetch_dataset("scores_1m", {"id": "caller-x"})
+
+            call_args = mock_client.get.call_args
+            assert (
+                call_args[0][0]
+                == "http://192.168.1.100:7080/api/v2/datasets/scores_1m.json"
+            )
+
+    @pytest.mark.asyncio
+    async def test_fetch_sets_user_agent_from_client_id(self, mock_httpx_response):
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_httpx_response
+
+            transport = HttpxDatasetTransport(
+                host="h",
+                port=7080,
+                client_id="my-app/1.2",
+                timeout=30.0,
+            )
+            await transport.fetch_dataset("scores_1m", {"id": "x"})
+
+            headers = mock_client.get.call_args[1]["headers"]
+            assert headers == {"Accept": "application/json", "User-Agent": "my-app/1.2"}
+
+    @pytest.mark.asyncio
+    async def test_fetch_passes_params_through(self, mock_httpx_response):
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_httpx_response
+
+            transport = HttpxDatasetTransport(
+                host="h",
+                port=7080,
+                client_id="ua",
+                timeout=30.0,
+            )
+            await transport.fetch_dataset(
+                "responsiveness_1s", {"id": "c", "start_time": 123, "end_time": 456}
+            )
+
+            params = mock_client.get.call_args[1]["params"]
+            assert params == {"id": "c", "start_time": 123, "end_time": 456}
+
+    @pytest.mark.asyncio
+    async def test_fetch_returns_parsed_json(self, mock_httpx_response):
+        mock_httpx_response.json.return_value = [{"orb_id": "x"}]
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_httpx_response
+
+            transport = HttpxDatasetTransport(
+                host="h",
+                port=7080,
+                client_id="ua",
+                timeout=30.0,
+            )
+            result = await transport.fetch_dataset("scores_1m", {"id": "x"})
+
+            assert result == [{"orb_id": "x"}]
+
+    @pytest.mark.asyncio
+    async def test_fetch_raises_on_http_status_error(self, mock_httpx_response):
+        mock_httpx_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404",
+            request=MagicMock(),
+            response=mock_httpx_response,
+        )
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_httpx_response
+
+            transport = HttpxDatasetTransport(
+                host="h",
+                port=7080,
+                client_id="ua",
+                timeout=30.0,
+            )
+            with pytest.raises(httpx.HTTPStatusError):
+                await transport.fetch_dataset("scores_1m", {"id": "x"})
+
+    @pytest.mark.asyncio
+    async def test_fetch_uses_configured_timeout(self, mock_httpx_response):
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_httpx_response
+
+            transport = HttpxDatasetTransport(
+                host="h",
+                port=7080,
+                client_id="ua",
+                timeout=12.5,
+            )
+            await transport.fetch_dataset("scores_1m", {"id": "x"})
+
+            init_kwargs = mock_client_class.call_args[1]
+            assert init_kwargs["timeout"] == 12.5


### PR DESCRIPTION
## Summary

Introduces a dataset-level transport seam at `OrbAPIClient` so test code never has to mock `httpx.AsyncClient` to exercise client behavior. First of four planned PRs from the architecture-improvement sweep.

- New module `src/orbnet/transport.py`: `DatasetTransport` Protocol + `HttpxDatasetTransport` production adapter.
- `OrbAPIClient.__init__` gains an optional `transport=` parameter (additive public API change). Default builds an `HttpxDatasetTransport` from existing config.
- Deletes `_get_dataset` and `_get_headers` from `OrbAPIClient`; their behavior moves entirely into the transport adapter.
- New `FakeDatasetTransport` in `tests/conftest.py`; ~30 tests in `tests/test_client.py` migrate from `patch("httpx.AsyncClient")` to `fake_transport` injection.
- `tests/test_transport.py` is now the only place httpx is mocked directly.

## Motivation

Tests were reaching past the `OrbAPIClient` interface to mock `httpx.AsyncClient` (~20 occurrences) while a second cluster patched the private `_get_dataset` method. Two test patterns reaching for two internal seams to test the same module — symptom of the seam being in the wrong place.

After: the interface is the test surface. Tests describe behavior in dataset terms; httpx is mocked exactly once, in `tests/test_transport.py`.

## Behavior changes (intentional)

- **Additive constructor parameter:** `OrbAPIClient(transport=...)` is a new optional kwarg; default behavior unchanged.
- **Config snapshot:** `HttpxDatasetTransport` snapshots host/port/client_id/timeout at construction. Mutating `client.config` post-init no longer alters request target/headers/timeout. Documented on `OrbAPIClient.__init__`. No consumer in this repo mutates `client.config`.

## Behavior preserved

- URL shape, header shape, query-param shape: identical.
- Per-call httpx lifecycle (fresh `AsyncClient` per fetch, `async with` exit): preserved and explicitly tested.
- Public method signatures (`get_*`, `poll_dataset`, `get_all_datasets`): unchanged.
- `OrbClientConfig` and `client.host` / `client.port` / etc. property surface: unchanged (touched in a planned follow-up PR).
- Wire format and error-envelope shape: unchanged.

## Scope of seam (honest framing)

The seam is currently httpx-shaped: `poll_dataset` catches `httpx.HTTPError` and `orbnet.errors` dispatches on httpx exception types. Alternate adapters must raise `httpx.HTTPError` subclasses for transport-level failures. A transport-neutral error type is future work, called out in `transport.py`'s module docstring.

## Test plan

- [x] `uv run pytest tests/ -q` → 237 passing
- [x] `uv run prek run --all-files --hook-stage pre-push` → all green (ruff check, ruff format, ty)
- [x] 100% coverage maintained
- [x] Independent Codex review (commit `852ac9a` addresses findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)