### PR TITLE
refactor: deepen DatasetSpec; table-driven MCP tools

### DIFF
--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import httpx
 
 from .datasets import DATASETS, DatasetSpec, parse_poll_alias
-from .errors import FAMILY_TO_TOOL_NAME, ErrorContext, translate_exception
+from .errors import ErrorContext, translate_exception
 from .models import (
     AllDatasetsRequestParams,
     AllDatasetsResponse,
@@ -170,19 +170,11 @@ class OrbAPIClient:
 
         Internal helper. The single place that turns raw JSON dicts into
         Pydantic record instances. Public methods (get_scores_1m, etc.) are
-        thin shims over this. `granularity` is validated against
-        `spec.granularities` here so dynamic callers get a clear ValueError
-        instead of an opaque HTTP 404 from a malformed wire name.
+        thin shims over this. `granularity` is validated by the spec so
+        dynamic callers get a clear ValueError instead of an opaque HTTP 404
+        from a malformed wire name.
         """
-        if (
-            granularity is not None
-            and spec.granularities
-            and granularity not in spec.granularities
-        ):
-            raise ValueError(
-                f"Invalid granularity {granularity!r} for {spec.family}. "
-                f"Valid: {', '.join(spec.granularities)}"
-            )
+        spec.validate_granularity(granularity)
 
         caller = caller_id or self.config.caller_id
         raw_data = await self._transport.fetch_dataset(
@@ -625,7 +617,7 @@ class OrbAPIClient:
         for (spec, g), result in zip(plan, results, strict=True):
             if isinstance(result, BaseException):
                 context = ErrorContext(
-                    tool=FAMILY_TO_TOOL_NAME[spec.family],
+                    tool=spec.tool_name,
                     granularity=g,
                 )
                 fields[spec.response_field(g)] = translate_exception(result, context)

--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -6,11 +6,11 @@ from importlib.metadata import version as get_version
 from typing import Any, cast
 
 import httpx
+from pydantic import TypeAdapter
 
 from .datasets import DATASETS, DatasetSpec, parse_poll_alias
 from .errors import ErrorContext, translate_exception
 from .models import (
-    AllDatasetsRequestParams,
     AllDatasetsResponse,
     Granularity,
     OrbClientConfig,
@@ -23,6 +23,10 @@ from .models import (
     WifiLinkRecord,
 )
 from .transport import DatasetTransport, HttpxDatasetTransport
+
+_GRANULARITY_ADAPTER: TypeAdapter[Granularity] = TypeAdapter(Granularity)
+_BOOL_ADAPTER: TypeAdapter[bool] = TypeAdapter(bool)
+_CALLER_ID_ADAPTER: TypeAdapter[str | None] = TypeAdapter(str | None)
 
 logger = logging.getLogger(__name__)
 
@@ -580,16 +584,17 @@ class OrbAPIClient:
             ...     else:
             ...         print(f"Failed to fetch {name}: {data.error}")
         """
-        request = AllDatasetsRequestParams(
-            caller_id=caller_id,
-            default_granularity=default_granularity,
-            include_all_responsiveness=include_all_responsiveness,
-            include_all_wifi_link=include_all_wifi_link,
+        _GRANULARITY_ADAPTER.validate_python(default_granularity)
+        # Pydantic bool coercion preserved: "false" → False, "true" → True, etc.
+        include_all_responsiveness = _BOOL_ADAPTER.validate_python(
+            include_all_responsiveness
         )
+        include_all_wifi_link = _BOOL_ADAPTER.validate_python(include_all_wifi_link)
+        caller_id = _CALLER_ID_ADAPTER.validate_python(caller_id)
 
         include_all_map = {
-            "responsiveness": request.include_all_responsiveness,
-            "wifi_link": request.include_all_wifi_link,
+            "responsiveness": include_all_responsiveness,
+            "wifi_link": include_all_wifi_link,
         }
 
         plan: list[tuple[DatasetSpec, Granularity | None]] = []
@@ -598,8 +603,8 @@ class OrbAPIClient:
                 plan.append((spec, None))
                 continue
             chosen = (
-                request.default_granularity
-                if request.default_granularity in spec.granularities
+                default_granularity
+                if default_granularity in spec.granularities
                 else spec.default_granularity
             )
             plan.append((spec, chosen))
@@ -609,7 +614,7 @@ class OrbAPIClient:
                         plan.append((spec, g))
 
         results = await asyncio.gather(
-            *[self._fetch(spec, g, request.caller_id) for spec, g in plan],
+            *[self._fetch(spec, g, caller_id) for spec, g in plan],
             return_exceptions=True,
         )
 

--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -584,7 +584,7 @@ class OrbAPIClient:
             ...     else:
             ...         print(f"Failed to fetch {name}: {data.error}")
         """
-        _GRANULARITY_ADAPTER.validate_python(default_granularity)
+        default_granularity = _GRANULARITY_ADAPTER.validate_python(default_granularity)
         # Pydantic bool coercion preserved: "false" → False, "true" → True, etc.
         include_all_responsiveness = _BOOL_ADAPTER.validate_python(
             include_all_responsiveness

--- a/src/orbnet/datasets.py
+++ b/src/orbnet/datasets.py
@@ -23,10 +23,16 @@ from .models import (
 class DatasetSpec:
     """Metadata describing one dataset family.
 
-    Three name spaces are tracked:
+    Four name spaces are tracked:
 
-    - `family`: the registry key. Public-method names follow `get_<family>`,
-      with the historical exception of `get_scores_1m` (family `scores`).
+    - `family`: the registry key. Internal Python-API method names follow
+      `get_<family>`, with the historical exception of `get_scores_1m`
+      (family `scores`).
+    - `tool_name`: the public MCP tool name (e.g. `orb_get_scores`). The
+      asymmetry between Python-API and MCP names is deliberate; both the
+      MCP-layer registration and the partial-failure `ErrorContext`
+      threading in `OrbAPIClient.get_all_datasets` read it from here so
+      there is a single source of truth.
     - `wire_name(granularity)`: the URL-path component used by the Orb API.
       Equals `family` for non-granular datasets, `f"{family}_{granularity}"`
       for granular ones, or `wire_name_override` when set.
@@ -39,6 +45,7 @@ class DatasetSpec:
 
     family: str
     record_class: type[BaseRecord]
+    tool_name: str
     granularities: tuple[Granularity, ...] = ()
     default_granularity: Granularity | None = None
     wire_name_override: str | None = None
@@ -55,32 +62,51 @@ class DatasetSpec:
             return f"{self.family}_{granularity or self.default_granularity}"
         return self.family
 
+    def validate_granularity(self, granularity: Granularity | None) -> None:
+        """Raise ValueError if `granularity` is not valid for this spec.
+
+        No-op when `self.granularities` is empty (non-granular dataset)
+        or when `granularity is None` (caller is asking for the default).
+        """
+        if granularity is None or not self.granularities:
+            return
+        if granularity not in self.granularities:
+            raise ValueError(
+                f"Invalid granularity {granularity!r} for {self.family}. "
+                f"Valid: {', '.join(self.granularities)}"
+            )
+
 
 DATASETS: dict[str, DatasetSpec] = {
     "scores": DatasetSpec(
         family="scores",
         record_class=ScoreRecord,
+        tool_name="orb_get_scores",
         granularities=("1m",),
         default_granularity="1m",
     ),
     "responsiveness": DatasetSpec(
         family="responsiveness",
         record_class=ResponsivenessRecord,
+        tool_name="orb_get_responsiveness",
         granularities=("1s", "15s", "1m"),
         default_granularity="1m",
     ),
     "web_responsiveness": DatasetSpec(
         family="web_responsiveness",
         record_class=WebResponsivenessRecord,
+        tool_name="orb_get_web_responsiveness",
         wire_name_override="web_responsiveness_results",
     ),
     "speed_results": DatasetSpec(
         family="speed_results",
         record_class=SpeedRecord,
+        tool_name="orb_get_speed_results",
     ),
     "wifi_link": DatasetSpec(
         family="wifi_link",
         record_class=WifiLinkRecord,
+        tool_name="orb_get_wifi_link",
         granularities=("1s", "15s", "1m"),
         default_granularity="1m",
     ),

--- a/src/orbnet/errors.py
+++ b/src/orbnet/errors.py
@@ -24,23 +24,6 @@ most retention-friendly granularity, and if it's unavailable the lower ones
 typically aren't enabled either)."""
 
 
-FAMILY_TO_TOOL_NAME: dict[str, str] = {
-    "scores": "orb_get_scores",
-    "responsiveness": "orb_get_responsiveness",
-    "web_responsiveness": "orb_get_web_responsiveness",
-    "speed_results": "orb_get_speed_results",
-    "wifi_link": "orb_get_wifi_link",
-}
-"""Maps `DatasetSpec.family` values to the canonical MCP tool name.
-
-Each MCP per-tool wrapper uses `<fn>.__name__` to populate
-`ErrorContext.tool` automatically; this table is the single hand-maintained
-mapping used by `OrbAPIClient.get_all_datasets`'s partial-failure path,
-where the loop iterates `(spec, granularity)` pairs and needs to map
-`spec.family` to the public tool name to thread into `ErrorContext`.
-"""
-
-
 class ErrorContext(BaseModel):
     """Per-call context threaded into `translate_exception`.
 

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -458,6 +458,11 @@ def _register_dataset_tool(
     client_method_name = (
         "get_scores_1m" if spec.family == "scores" else f"get_{spec.family}"
     )
+    if not hasattr(OrbAPIClient, client_method_name):
+        raise RuntimeError(
+            f"_register_dataset_tool: OrbAPIClient has no method "
+            f"{client_method_name!r} for spec family {spec.family!r}"
+        )
     # Construct `list[<record_type>] | ErrorPayload` at runtime. ty cannot
     # evaluate `list[record_type]` as a type expression because record_type
     # is a parameter, but FastMCP only needs the runtime type object.

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -27,9 +27,11 @@ from pydantic import BaseModel, Field, ValidationError
 
 from . import __version__
 from .client import OrbAPIClient
+from .datasets import DATASETS, DatasetSpec
 from .errors import ErrorContext, translate_exception
 from .models import (
     AllDatasetsResponse,
+    BaseRecord,
     ErrorPayload,
     Granularity,
     ResponsivenessRecord,
@@ -167,19 +169,7 @@ def get_client(
     )
 
 
-@mcp.tool(
-    title="Get Scores Dataset",
-    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
-    tags={"orb", "scores"},
-)
-async def orb_get_scores(
-    ctx: Context,
-    host: str | None = None,
-    port: int | None = None,
-    caller_id: str | None = None,
-    timeout: float | None = None,
-) -> list[ScoreRecord] | ErrorPayload:
-    """
+_SCORES_DOCSTRING = """
     Retrieve 1-minute granularity Scores dataset from an Orb sensor.
 
     The Scores Dataset includes Orb Score and its component scores (Responsiveness,
@@ -251,28 +241,9 @@ async def orb_get_scores(
             }
         ]
     """
-    client = get_client(host, port, caller_id, timeout)
-    await ctx.info(f"Getting 1m scores from Orb sensor {client.host}...")
-    try:
-        return await client.get_scores_1m()
-    except (httpx.HTTPError, ValidationError) as exc:
-        return translate_exception(exc, ErrorContext(tool=orb_get_scores.__name__))
 
 
-@mcp.tool(
-    title="Get Responsiveness Dataset",
-    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
-    tags={"orb", "responsiveness"},
-)
-async def orb_get_responsiveness(
-    ctx: Context,
-    host: str | None = None,
-    granularity: Granularity = "1m",
-    port: int | None = None,
-    caller_id: str | None = None,
-    timeout: float | None = None,
-) -> list[ResponsivenessRecord] | ErrorPayload:
-    """
+_RESPONSIVENESS_DOCSTRING = """
     Retrieve Responsiveness dataset from an Orb sensor at a single granularity.
 
     This tool fetches ONE granularity at a time. To fetch all granularities at
@@ -330,30 +301,9 @@ async def orb_get_responsiveness(
 
     Empty list [] if no new data since last poll.
     """
-    client = get_client(host, port, caller_id, timeout)
-    await ctx.info(f"Getting responsiveness data from Orb sensor {client.host}...")
-    try:
-        return await client.get_responsiveness(granularity=granularity)
-    except (httpx.HTTPError, ValidationError) as exc:
-        return translate_exception(
-            exc,
-            ErrorContext(tool=orb_get_responsiveness.__name__, granularity=granularity),
-        )
 
 
-@mcp.tool(
-    title="Get Web Responsiveness Dataset",
-    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
-    tags={"orb", "web-performance"},
-)
-async def orb_get_web_responsiveness(
-    ctx: Context,
-    host: str | None = None,
-    port: int | None = None,
-    caller_id: str | None = None,
-    timeout: float | None = None,
-) -> list[WebResponsivenessRecord] | ErrorPayload:
-    """
+_WEB_RESPONSIVENESS_DOCSTRING = """
     Retrieve Web Responsiveness dataset from an Orb sensor.
 
     Includes Time to First Byte (TTFB) for web page loads and DNS resolver
@@ -381,29 +331,9 @@ async def orb_get_web_responsiveness(
         - network_type: Network interface type
         - And more...
     """
-    client = get_client(host, port, caller_id, timeout)
-    await ctx.info(f"Getting web responsiveness data from Orb sensor {client.host}...")
-    try:
-        return await client.get_web_responsiveness()
-    except (httpx.HTTPError, ValidationError) as exc:
-        return translate_exception(
-            exc, ErrorContext(tool=orb_get_web_responsiveness.__name__)
-        )
 
 
-@mcp.tool(
-    title="Get Speed Test Results",
-    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
-    tags={"orb", "speed"},
-)
-async def orb_get_speed_results(
-    ctx: Context,
-    host: str | None = None,
-    port: int | None = None,
-    caller_id: str | None = None,
-    timeout: float | None = None,
-) -> list[SpeedRecord] | ErrorPayload:
-    """
+_SPEED_RESULTS_DOCSTRING = """
     Retrieve Speed test results dataset from an Orb sensor.
 
     Includes download and upload speed test results. Content speed measurements
@@ -431,30 +361,9 @@ async def orb_get_speed_results(
         - timestamp: Test timestamp in epoch milliseconds
         - network_type: Network interface type
     """
-    client = get_client(host, port, caller_id, timeout)
-    await ctx.info(f"Getting speed test data from Orb sensor {client.host}...")
-    try:
-        return await client.get_speed_results()
-    except (httpx.HTTPError, ValidationError) as exc:
-        return translate_exception(
-            exc, ErrorContext(tool=orb_get_speed_results.__name__)
-        )
 
 
-@mcp.tool(
-    title="Get Wi-Fi Link Dataset",
-    annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
-    tags={"orb", "wifi"},
-)
-async def orb_get_wifi_link(
-    ctx: Context,
-    host: str | None = None,
-    granularity: Granularity = "1m",
-    port: int | None = None,
-    caller_id: str | None = None,
-    timeout: float | None = None,
-) -> list[WifiLinkRecord] | ErrorPayload:
-    """
+_WIFI_LINK_DOCSTRING = """
     Retrieve Wi-Fi Link dataset from an Orb sensor at a single granularity.
 
     This tool fetches ONE granularity at a time. To fetch all granularities at
@@ -509,15 +418,153 @@ async def orb_get_wifi_link(
         "Why is my Wi-Fi slow even though my internet plan is fast?"
         "Show me my Wi-Fi signal strength over the last hour"
     """
-    client = get_client(host, port, caller_id, timeout)
-    await ctx.info(f"Getting Wi-Fi link data from Orb sensor {client.host}...")
-    try:
-        return await client.get_wifi_link(granularity=granularity)
-    except (httpx.HTTPError, ValidationError) as exc:
-        return translate_exception(
-            exc,
-            ErrorContext(tool=orb_get_wifi_link.__name__, granularity=granularity),
-        )
+
+
+def _register_dataset_tool(
+    spec: DatasetSpec,
+    *,
+    title: str,
+    tags: set[str],
+    docstring: str,
+    granular: bool,
+    record_type: type[BaseRecord],
+) -> None:
+    """Register a FastMCP tool for one dataset family.
+
+    The tool body is the same for every family modulo (a) which client
+    method to call and (b) whether `granularity` is exposed and threaded
+    into ErrorContext. This factory bakes the body once; each per-family
+    registration is then a single declarative call.
+
+    `granular=True` exposes a `granularity` parameter and uses
+    `spec.default_granularity` as its default. The granularity is also
+    threaded into ErrorContext so 404 fallback hints reach
+    granularity_unavailable.
+
+    `granular=False` omits the parameter; `ErrorContext.granularity` is
+    None so 404s become dataset_not_found.
+
+    `client_method_name` is derived from the spec: `get_scores_1m` for
+    the scores family (historical exception preserved); `get_<family>`
+    for everything else.
+
+    `record_type` becomes the success branch of the tool's return
+    annotation (`list[record_type] | ErrorPayload`). FastMCP reads
+    this annotation to derive `output_schema`; without it, the union
+    shape pinned by `TestMCPOutputSchemaIsUnion` would silently
+    collapse.
+    """
+    tool_name = spec.tool_name
+    client_method_name = (
+        "get_scores_1m" if spec.family == "scores" else f"get_{spec.family}"
+    )
+    # Construct `list[<record_type>] | ErrorPayload` at runtime. ty cannot
+    # evaluate `list[record_type]` as a type expression because record_type
+    # is a parameter, but FastMCP only needs the runtime type object.
+    return_type = list[record_type] | ErrorPayload  # type: ignore[valid-type]  # ty: ignore[invalid-type-form]
+
+    if granular:
+        default_granularity = spec.default_granularity
+
+        async def _tool(
+            ctx: Context,
+            host: str | None = None,
+            granularity: Granularity = default_granularity,  # type: ignore[assignment]  # ty: ignore[invalid-parameter-default]
+            port: int | None = None,
+            caller_id: str | None = None,
+            timeout: float | None = None,
+        ):
+            client = get_client(host, port, caller_id, timeout)
+            await ctx.info(
+                f"Getting {spec.family} data from Orb sensor {client.host}..."
+            )
+            try:
+                method = getattr(client, client_method_name)
+                return await method(granularity=granularity)
+            except (httpx.HTTPError, ValidationError) as exc:
+                return translate_exception(
+                    exc,
+                    ErrorContext(tool=tool_name, granularity=granularity),
+                )
+
+    else:
+
+        async def _tool(  # type: ignore[no-redef]
+            ctx: Context,
+            host: str | None = None,
+            port: int | None = None,
+            caller_id: str | None = None,
+            timeout: float | None = None,
+        ):
+            client = get_client(host, port, caller_id, timeout)
+            await ctx.info(
+                f"Getting {spec.family} data from Orb sensor {client.host}..."
+            )
+            try:
+                method = getattr(client, client_method_name)
+                return await method()
+            except (httpx.HTTPError, ValidationError) as exc:
+                return translate_exception(exc, ErrorContext(tool=tool_name))
+
+    _tool.__name__ = tool_name
+    _tool.__doc__ = docstring
+    # Set return annotation explicitly so FastMCP's output_schema derivation
+    # sees `list[<Record>] | ErrorPayload` instead of an inference fallback.
+    _tool.__annotations__["return"] = return_type
+    # Bind to module globals so existing tests that call mcp_server.orb_get_<x>
+    # directly continue to work.
+    globals()[tool_name] = _tool
+    mcp.tool(
+        title=title,
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        tags=tags,
+    )(_tool)
+
+
+_register_dataset_tool(
+    DATASETS["scores"],
+    title="Get Scores Dataset",
+    tags={"orb", "scores"},
+    docstring=_SCORES_DOCSTRING,
+    granular=False,
+    record_type=ScoreRecord,
+)
+
+_register_dataset_tool(
+    DATASETS["responsiveness"],
+    title="Get Responsiveness Dataset",
+    tags={"orb", "responsiveness"},
+    docstring=_RESPONSIVENESS_DOCSTRING,
+    granular=True,
+    record_type=ResponsivenessRecord,
+)
+
+_register_dataset_tool(
+    DATASETS["web_responsiveness"],
+    title="Get Web Responsiveness Dataset",
+    tags={"orb", "web-performance"},
+    docstring=_WEB_RESPONSIVENESS_DOCSTRING,
+    granular=False,
+    record_type=WebResponsivenessRecord,
+)
+
+_register_dataset_tool(
+    DATASETS["speed_results"],
+    title="Get Speed Test Results",
+    tags={"orb", "speed"},
+    docstring=_SPEED_RESULTS_DOCSTRING,
+    granular=False,
+    record_type=SpeedRecord,
+)
+
+_register_dataset_tool(
+    DATASETS["wifi_link"],
+    title="Get Wi-Fi Link Dataset",
+    tags={"orb", "wifi"},
+    docstring=_WIFI_LINK_DOCSTRING,
+    granular=True,
+    record_type=WifiLinkRecord,
+)
 
 
 @mcp.tool(

--- a/src/orbnet/mcp_server.py
+++ b/src/orbnet/mcp_server.py
@@ -31,14 +31,8 @@ from .datasets import DATASETS, DatasetSpec
 from .errors import ErrorContext, translate_exception
 from .models import (
     AllDatasetsResponse,
-    BaseRecord,
     ErrorPayload,
     Granularity,
-    ResponsivenessRecord,
-    ScoreRecord,
-    SpeedRecord,
-    WebResponsivenessRecord,
-    WifiLinkRecord,
 )
 
 SERVER_FINGERPRINT = f"orbnet@{__version__}"
@@ -427,7 +421,6 @@ def _register_dataset_tool(
     tags: set[str],
     docstring: str,
     granular: bool,
-    record_type: type[BaseRecord],
 ) -> None:
     """Register a FastMCP tool for one dataset family.
 
@@ -448,11 +441,13 @@ def _register_dataset_tool(
     the scores family (historical exception preserved); `get_<family>`
     for everything else.
 
-    `record_type` becomes the success branch of the tool's return
-    annotation (`list[record_type] | ErrorPayload`). FastMCP reads
-    this annotation to derive `output_schema`; without it, the union
-    shape pinned by `TestMCPOutputSchemaIsUnion` would silently
-    collapse.
+    The return annotation is derived from `spec.record_class` as
+    `list[spec.record_class] | ErrorPayload`. FastMCP reads this
+    annotation to derive `output_schema`; without it the union shape
+    pinned by `TestMCPOutputSchemaIsUnion` would silently collapse.
+    Sourcing from the spec keeps the registry the single source of
+    truth — there's no second `record_type` parameter that could
+    drift out of sync with `spec.record_class`.
     """
     tool_name = spec.tool_name
     client_method_name = (
@@ -463,10 +458,11 @@ def _register_dataset_tool(
             f"_register_dataset_tool: OrbAPIClient has no method "
             f"{client_method_name!r} for spec family {spec.family!r}"
         )
-    # Construct `list[<record_type>] | ErrorPayload` at runtime. ty cannot
-    # evaluate `list[record_type]` as a type expression because record_type
-    # is a parameter, but FastMCP only needs the runtime type object.
-    return_type = list[record_type] | ErrorPayload  # type: ignore[valid-type]  # ty: ignore[invalid-type-form]
+    # Construct `list[<record_class>] | ErrorPayload` at runtime. ty cannot
+    # evaluate `list[spec.record_class]` as a type expression because
+    # spec.record_class is an attribute access, but FastMCP only needs the
+    # runtime type object.
+    return_type = list[spec.record_class] | ErrorPayload  # type: ignore[valid-type]  # ty: ignore[invalid-type-form]
 
     if granular:
         default_granularity = spec.default_granularity
@@ -532,7 +528,6 @@ _register_dataset_tool(
     tags={"orb", "scores"},
     docstring=_SCORES_DOCSTRING,
     granular=False,
-    record_type=ScoreRecord,
 )
 
 _register_dataset_tool(
@@ -541,7 +536,6 @@ _register_dataset_tool(
     tags={"orb", "responsiveness"},
     docstring=_RESPONSIVENESS_DOCSTRING,
     granular=True,
-    record_type=ResponsivenessRecord,
 )
 
 _register_dataset_tool(
@@ -550,7 +544,6 @@ _register_dataset_tool(
     tags={"orb", "web-performance"},
     docstring=_WEB_RESPONSIVENESS_DOCSTRING,
     granular=False,
-    record_type=WebResponsivenessRecord,
 )
 
 _register_dataset_tool(
@@ -559,7 +552,6 @@ _register_dataset_tool(
     tags={"orb", "speed"},
     docstring=_SPEED_RESULTS_DOCSTRING,
     granular=False,
-    record_type=SpeedRecord,
 )
 
 _register_dataset_tool(
@@ -568,7 +560,6 @@ _register_dataset_tool(
     tags={"orb", "wifi"},
     docstring=_WIFI_LINK_DOCSTRING,
     granular=True,
-    record_type=WifiLinkRecord,
 )
 
 

--- a/src/orbnet/models.py
+++ b/src/orbnet/models.py
@@ -45,41 +45,6 @@ class OrbClientConfig(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
 
 
-class DatasetRequestParams(BaseModel):
-    """Parameters for dataset requests"""
-
-    caller_id: str | None = Field(
-        default=None, description="Override the default caller_id for this request"
-    )
-
-    model_config = ConfigDict(extra="allow")
-
-
-class ResponsivenessRequestParams(DatasetRequestParams):
-    """Parameters for responsiveness dataset requests"""
-
-    granularity: Granularity = Field(
-        default="1m", description="Time bucket size - '1s', '15s', or '1m'"
-    )
-
-
-class AllDatasetsRequestParams(DatasetRequestParams):
-    """Parameters for fetching all datasets"""
-
-    default_granularity: Granularity = Field(
-        default="1m",
-        description="Default time-bucket size for granular datasets (responsiveness, wifi_link).",  # noqa: E501
-    )
-    include_all_responsiveness: bool = Field(
-        default=False,
-        description="If True, fetches all responsiveness granularities (1s, 15s, 1m). If False, only fetches 1m.",  # noqa: E501
-    )
-    include_all_wifi_link: bool = Field(
-        default=False,
-        description="If True, fetches all Wi-Fi Link granularities (1s, 15s, 1m). If False, only fetches 1m.",  # noqa: E501
-    )
-
-
 class PollingConfig(BaseModel):
     """Configuration for polling datasets"""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -656,14 +656,6 @@ class TestGetAllDatasetsPlan:
         assert result.wifi_link_15s is None
         assert result.wifi_link_1s is None
 
-    @pytest.mark.asyncio
-    async def test_invalid_default_granularity_raises(self):
-        from pydantic import ValidationError
-
-        client = OrbAPIClient(host="192.168.1.100")
-        with pytest.raises(ValidationError):
-            await client.get_all_datasets(default_granularity="bogus")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
-
 
 class TestPollDatasetCallbackContract:
     """The user-supplied dataset_name string must reach callbacks unchanged.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -853,6 +853,58 @@ class TestGranularityValidation:
             await client.get_responsiveness(granularity="bogus")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
 
 
+class TestGetAllDatasetsValidation:
+    """The deleted AllDatasetsRequestParams validated default_granularity
+    (Literal), the two include_all_* flags (bool with coercion), and
+    caller_id (str | None). Confirm equivalent validation now lives at
+    the get_all_datasets entrypoint via TypeAdapter."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_default_granularity_raises(self):
+        from pydantic import ValidationError
+
+        client = OrbAPIClient(host="192.168.1.100")
+        with pytest.raises(ValidationError):
+            await client.get_all_datasets(default_granularity="bogus")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
+
+    @pytest.mark.asyncio
+    async def test_string_false_coerces_to_false_for_include_flags(
+        self, fake_transport
+    ):
+        """Pydantic bool coercion is preserved: passing the string 'false'
+        for include_all_* must coerce to False (not be truthy)."""
+        for wire_name in (
+            "scores_1m",
+            "responsiveness_1m",
+            "web_responsiveness_results",
+            "speed_results",
+            "wifi_link_1m",
+        ):
+            fake_transport.responses[wire_name] = []
+
+        client = OrbAPIClient(host="192.168.1.100", transport=fake_transport)
+        result = await client.get_all_datasets(
+            include_all_responsiveness="false",  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
+            include_all_wifi_link="false",  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
+        )
+
+        # If "false" had been treated truthily, all 3 responsiveness
+        # granularities would be in the plan; the bool coercion ensures
+        # only the default 1m is fetched.
+        assert result.responsiveness_1s is None
+        assert result.responsiveness_15s is None
+        assert result.wifi_link_1s is None
+        assert result.wifi_link_15s is None
+
+    @pytest.mark.asyncio
+    async def test_non_string_caller_id_raises(self):
+        from pydantic import ValidationError
+
+        client = OrbAPIClient(host="192.168.1.100")
+        with pytest.raises(ValidationError):
+            await client.get_all_datasets(caller_id=12345)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
+
+
 class TestGetAllDatasetsErrorContext:
     """When a per-fetch task in get_all_datasets raises, the resulting
     ErrorPayload must include the structured code/repair from

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -239,7 +239,7 @@ class TestDatasetSpecValidateGranularity:
         from orbnet.datasets import DATASETS
 
         with pytest.raises(ValueError, match="Invalid granularity"):
-            DATASETS["responsiveness"].validate_granularity("2m")  # type: ignore[arg-type]
+            DATASETS["responsiveness"].validate_granularity("2m")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
 
     def test_error_message_lists_valid_granularities(self):
         import pytest
@@ -247,7 +247,7 @@ class TestDatasetSpecValidateGranularity:
         from orbnet.datasets import DATASETS
 
         with pytest.raises(ValueError, match="1s, 15s, 1m"):
-            DATASETS["responsiveness"].validate_granularity("bogus")  # type: ignore[arg-type]
+            DATASETS["responsiveness"].validate_granularity("bogus")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
 
     def test_non_granular_dataset_accepts_none(self):
         from orbnet.datasets import DATASETS
@@ -263,4 +263,4 @@ class TestDatasetSpecValidateGranularity:
         from orbnet.datasets import DATASETS
 
         # No exception even though "1s" isn't meaningful for this dataset.
-        DATASETS["speed_results"].validate_granularity("1s")  # type: ignore[arg-type]
+        DATASETS["speed_results"].validate_granularity("1s")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -14,17 +14,26 @@ from orbnet.models import (
 
 class TestDatasetSpec:
     def test_non_granular_wire_name(self):
-        spec = DatasetSpec(family="speed_results", record_class=SpeedRecord)
+        spec = DatasetSpec(
+            family="speed_results",
+            record_class=SpeedRecord,
+            tool_name="orb_get_speed_results",
+        )
         assert spec.wire_name() == "speed_results"
 
     def test_non_granular_response_field(self):
-        spec = DatasetSpec(family="speed_results", record_class=SpeedRecord)
+        spec = DatasetSpec(
+            family="speed_results",
+            record_class=SpeedRecord,
+            tool_name="orb_get_speed_results",
+        )
         assert spec.response_field() == "speed_results"
 
     def test_granular_wire_name_explicit_granularity(self):
         spec = DatasetSpec(
             family="responsiveness",
             record_class=ResponsivenessRecord,
+            tool_name="orb_get_responsiveness",
             granularities=("1s", "15s", "1m"),
             default_granularity="1m",
         )
@@ -36,6 +45,7 @@ class TestDatasetSpec:
         spec = DatasetSpec(
             family="responsiveness",
             record_class=ResponsivenessRecord,
+            tool_name="orb_get_responsiveness",
             granularities=("1s", "15s", "1m"),
             default_granularity="1m",
         )
@@ -45,6 +55,7 @@ class TestDatasetSpec:
         spec = DatasetSpec(
             family="responsiveness",
             record_class=ResponsivenessRecord,
+            tool_name="orb_get_responsiveness",
             granularities=("1s", "15s", "1m"),
             default_granularity="1m",
         )
@@ -55,6 +66,7 @@ class TestDatasetSpec:
         spec = DatasetSpec(
             family="web_responsiveness",
             record_class=WebResponsivenessRecord,
+            tool_name="orb_get_web_responsiveness",
             wire_name_override="web_responsiveness_results",
         )
         assert spec.wire_name() == "web_responsiveness_results"
@@ -65,6 +77,7 @@ class TestDatasetSpec:
         spec = DatasetSpec(
             family="web_responsiveness",
             record_class=WebResponsivenessRecord,
+            tool_name="orb_get_web_responsiveness",
             wire_name_override="web_responsiveness_results",
         )
         assert spec.response_field() == "web_responsiveness"
@@ -176,3 +189,78 @@ class TestPollAliases:
 
         with pytest.raises(ValueError, match="Unknown dataset: bogus"):
             parse_poll_alias("bogus")
+
+
+class TestDatasetSpecToolName:
+    """Each registry entry exposes its public MCP tool name. Used by both
+    the MCP layer (for registration) and OrbAPIClient.get_all_datasets
+    (to thread tool name into ErrorContext for the partial-failure path)."""
+
+    def test_scores_tool_name(self):
+        from orbnet.datasets import DATASETS
+
+        assert DATASETS["scores"].tool_name == "orb_get_scores"
+
+    def test_responsiveness_tool_name(self):
+        from orbnet.datasets import DATASETS
+
+        assert DATASETS["responsiveness"].tool_name == "orb_get_responsiveness"
+
+    def test_web_responsiveness_tool_name(self):
+        from orbnet.datasets import DATASETS
+
+        assert DATASETS["web_responsiveness"].tool_name == "orb_get_web_responsiveness"
+
+    def test_speed_results_tool_name(self):
+        from orbnet.datasets import DATASETS
+
+        assert DATASETS["speed_results"].tool_name == "orb_get_speed_results"
+
+    def test_wifi_link_tool_name(self):
+        from orbnet.datasets import DATASETS
+
+        assert DATASETS["wifi_link"].tool_name == "orb_get_wifi_link"
+
+
+class TestDatasetSpecValidateGranularity:
+    """spec.validate_granularity(g) raises ValueError for granularities not
+    in spec.granularities. Used by OrbAPIClient._fetch."""
+
+    def test_valid_granularity_returns_none(self):
+        from orbnet.datasets import DATASETS
+
+        # No exception, returns None implicitly.
+        result = DATASETS["responsiveness"].validate_granularity("1s")
+        assert result is None
+
+    def test_invalid_granularity_raises_value_error(self):
+        import pytest
+
+        from orbnet.datasets import DATASETS
+
+        with pytest.raises(ValueError, match="Invalid granularity"):
+            DATASETS["responsiveness"].validate_granularity("2m")  # type: ignore[arg-type]
+
+    def test_error_message_lists_valid_granularities(self):
+        import pytest
+
+        from orbnet.datasets import DATASETS
+
+        with pytest.raises(ValueError, match="1s, 15s, 1m"):
+            DATASETS["responsiveness"].validate_granularity("bogus")  # type: ignore[arg-type]
+
+    def test_non_granular_dataset_accepts_none(self):
+        from orbnet.datasets import DATASETS
+
+        # speed_results has no granularities; validating None is a no-op.
+        result = DATASETS["speed_results"].validate_granularity(None)
+        assert result is None
+
+    def test_non_granular_dataset_silently_accepts_anything(self):
+        """When spec.granularities is empty, validation is a no-op even
+        for arbitrary input. Matches today's _fetch behavior (the inline
+        check skipped validation when spec.granularities was empty)."""
+        from orbnet.datasets import DATASETS
+
+        # No exception even though "1s" isn't meaningful for this dataset.
+        DATASETS["speed_results"].validate_granularity("1s")  # type: ignore[arg-type]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,7 +8,6 @@ import httpx
 import pytest
 
 from orbnet.errors import (
-    FAMILY_TO_TOOL_NAME,
     GRANULARITY_FALLBACK,
     ErrorContext,
 )
@@ -80,18 +79,6 @@ class TestGranularityFallbackChain:
 
         granularity_values = set(get_args(Granularity.__value__))
         assert set(GRANULARITY_FALLBACK.keys()) == granularity_values
-
-
-class TestFamilyToToolName:
-    def test_scores_family_maps_to_orb_get_scores(self):
-        assert FAMILY_TO_TOOL_NAME["scores"] == "orb_get_scores"
-
-    @pytest.mark.parametrize(
-        "family",
-        ["responsiveness", "web_responsiveness", "speed_results", "wifi_link"],
-    )
-    def test_other_families_round_trip(self, family: str):
-        assert FAMILY_TO_TOOL_NAME[family] == f"orb_get_{family}"
 
 
 class TestErrorContext:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -45,37 +45,17 @@ class TestIntegration:
         assert info["base_url"] == "http://test-host:8080"
 
     def test_model_validation_integration(self):
-        """Test that models work together in realistic scenarios."""
-        from orbnet.models import (
-            AllDatasetsRequestParams,
-            DatasetRequestParams,
-            OrbClientConfig,
-            ResponsivenessRequestParams,
-        )
+        """Test that OrbClientConfig validates a realistic configuration."""
+        from orbnet.models import OrbClientConfig
 
-        # Test configuration chain
         config = OrbClientConfig(
             host="test-host", port=8080, caller_id="test-caller", timeout=30.0
         )
 
-        # Test dataset request with config values
-        dataset_params = DatasetRequestParams(caller_id=config.caller_id)
-
-        # Test responsiveness request
-        resp_params = ResponsivenessRequestParams(
-            granularity="1s", caller_id=config.caller_id
-        )
-
-        # Test all datasets request
-        all_params = AllDatasetsRequestParams(
-            caller_id=config.caller_id, include_all_responsiveness=True
-        )
-
-        # Verify all parameters are valid
-        assert dataset_params.caller_id == config.caller_id
-        assert resp_params.caller_id == config.caller_id
-        assert all_params.caller_id == config.caller_id
-        assert all_params.include_all_responsiveness is True
+        assert config.host == "test-host"
+        assert config.port == 8080
+        assert config.caller_id == "test-caller"
+        assert config.timeout == 30.0
 
     @pytest.mark.asyncio
     async def test_polling_configuration_integration(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,19 +44,6 @@ class TestIntegration:
         assert info["timeout"] == 45.0
         assert info["base_url"] == "http://test-host:8080"
 
-    def test_model_validation_integration(self):
-        """Test that OrbClientConfig validates a realistic configuration."""
-        from orbnet.models import OrbClientConfig
-
-        config = OrbClientConfig(
-            host="test-host", port=8080, caller_id="test-caller", timeout=30.0
-        )
-
-        assert config.host == "test-host"
-        assert config.port == 8080
-        assert config.caller_id == "test-caller"
-        assert config.timeout == 30.0
-
     @pytest.mark.asyncio
     async def test_polling_configuration_integration(self):
         """Test that polling configuration works with client."""

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -183,11 +183,12 @@ def test_register_dataset_tool_raises_for_missing_client_method():
 
     from orbnet.datasets import DATASETS
     from orbnet.mcp_server import _register_dataset_tool
-    from orbnet.models import ScoreRecord
 
-    # Mutate scores spec to point at a nonexistent family name. The
-    # factory derives client_method_name = f"get_{spec.family}" for
-    # non-scores families.
+    # Use the responsiveness spec (a standard granular family) and
+    # mutate its `family` to a nonexistent name. The factory derives
+    # client_method_name = f"get_{spec.family}" for non-scores families,
+    # so the registration-time hasattr check should fire on the
+    # missing OrbAPIClient.get_bogus_family.
     bogus_spec = replace(DATASETS["responsiveness"], family="bogus_family")
 
     with pytest.raises(RuntimeError, match="bogus_family"):
@@ -197,7 +198,6 @@ def test_register_dataset_tool_raises_for_missing_client_method():
             tags={"orb"},
             docstring="bogus",
             granular=True,
-            record_type=ScoreRecord,
         )
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -175,6 +175,32 @@ async def test_mcp_tool_no_arg_forwards_client_default_granularity(
     assert forwarded == client_default
 
 
+def test_register_dataset_tool_raises_for_missing_client_method():
+    """Registration-time invariant: the spec must reference an
+    OrbAPIClient method that exists. Catches typos in spec.family or
+    a registry entry added without a corresponding client method."""
+    from dataclasses import replace
+
+    from orbnet.datasets import DATASETS
+    from orbnet.mcp_server import _register_dataset_tool
+    from orbnet.models import ScoreRecord
+
+    # Mutate scores spec to point at a nonexistent family name. The
+    # factory derives client_method_name = f"get_{spec.family}" for
+    # non-scores families.
+    bogus_spec = replace(DATASETS["responsiveness"], family="bogus_family")
+
+    with pytest.raises(RuntimeError, match="bogus_family"):
+        _register_dataset_tool(
+            bogus_spec,
+            title="Bogus",
+            tags={"orb"},
+            docstring="bogus",
+            granular=True,
+            record_type=ScoreRecord,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Tool metadata tests (FastMCP 3.2: title, tags, ToolAnnotations)
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -37,32 +37,32 @@ def ctx():
 
 
 async def test_orb_get_scores_tool(mock_client, ctx):
-    result = await mcp_server.orb_get_scores(ctx, host="h")
+    result = await mcp_server.orb_get_scores(ctx, host="h")  # ty: ignore[unresolved-attribute]
     assert result == []
     mock_client.get_scores_1m.assert_awaited_once()
     ctx.info.assert_awaited_once()
 
 
 async def test_orb_get_responsiveness_tool(mock_client, ctx):
-    result = await mcp_server.orb_get_responsiveness(ctx, host="h", granularity="1s")
+    result = await mcp_server.orb_get_responsiveness(ctx, host="h", granularity="1s")  # ty: ignore[unresolved-attribute]  # noqa: E501
     assert result == []
     mock_client.get_responsiveness.assert_awaited_once_with(granularity="1s")
 
 
 async def test_orb_get_web_responsiveness_tool(mock_client, ctx):
-    result = await mcp_server.orb_get_web_responsiveness(ctx, host="h")
+    result = await mcp_server.orb_get_web_responsiveness(ctx, host="h")  # ty: ignore[unresolved-attribute]
     assert result == []
     mock_client.get_web_responsiveness.assert_awaited_once()
 
 
 async def test_orb_get_speed_results_tool(mock_client, ctx):
-    result = await mcp_server.orb_get_speed_results(ctx, host="h")
+    result = await mcp_server.orb_get_speed_results(ctx, host="h")  # ty: ignore[unresolved-attribute]
     assert result == []
     mock_client.get_speed_results.assert_awaited_once()
 
 
 async def test_orb_get_wifi_link_tool(mock_client, ctx):
-    result = await mcp_server.orb_get_wifi_link(ctx, host="h", granularity="15s")
+    result = await mcp_server.orb_get_wifi_link(ctx, host="h", granularity="15s")  # ty: ignore[unresolved-attribute]
     assert result == []
     mock_client.get_wifi_link.assert_awaited_once_with(granularity="15s")
 
@@ -123,8 +123,8 @@ def test_main_invokes_mcp_run(mocker):
 @pytest.mark.parametrize(
     ("mcp_tool", "client_method"),
     [
-        (mcp_server.orb_get_responsiveness, OrbAPIClient.get_responsiveness),
-        (mcp_server.orb_get_wifi_link, OrbAPIClient.get_wifi_link),
+        (mcp_server.orb_get_responsiveness, OrbAPIClient.get_responsiveness),  # ty: ignore[unresolved-attribute]
+        (mcp_server.orb_get_wifi_link, OrbAPIClient.get_wifi_link),  # ty: ignore[unresolved-attribute]
     ],
 )
 def test_mcp_tool_granularity_default_matches_client(mcp_tool, client_method):
@@ -158,8 +158,8 @@ async def test_orb_get_all_datasets_forwards_client_default_granularity(
 @pytest.mark.parametrize(
     ("mcp_tool", "client_method_attr"),
     [
-        (mcp_server.orb_get_responsiveness, "get_responsiveness"),
-        (mcp_server.orb_get_wifi_link, "get_wifi_link"),
+        (mcp_server.orb_get_responsiveness, "get_responsiveness"),  # ty: ignore[unresolved-attribute]
+        (mcp_server.orb_get_wifi_link, "get_wifi_link"),  # ty: ignore[unresolved-attribute]
     ],
 )
 async def test_mcp_tool_no_arg_forwards_client_default_granularity(
@@ -180,55 +180,29 @@ async def test_mcp_tool_no_arg_forwards_client_default_granularity(
 # ---------------------------------------------------------------------------
 
 
-async def test_tool_metadata_orb_get_scores():
-    tool = await mcp_server.mcp.get_tool("orb_get_scores")
+@pytest.mark.parametrize(
+    ("tool_name", "expected_title", "expected_tags"),
+    [
+        ("orb_get_scores", "Get Scores Dataset", {"orb", "scores"}),
+        (
+            "orb_get_responsiveness",
+            "Get Responsiveness Dataset",
+            {"orb", "responsiveness"},
+        ),
+        (
+            "orb_get_web_responsiveness",
+            "Get Web Responsiveness Dataset",
+            {"orb", "web-performance"},
+        ),
+        ("orb_get_speed_results", "Get Speed Test Results", {"orb", "speed"}),
+        ("orb_get_wifi_link", "Get Wi-Fi Link Dataset", {"orb", "wifi"}),
+    ],
+)
+async def test_dataset_tool_metadata(tool_name, expected_title, expected_tags):
+    tool = await mcp_server.mcp.get_tool(tool_name)
     assert tool is not None
-    assert tool.title == "Get Scores Dataset"
-    assert tool.tags == {"orb", "scores"}
-    assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is True
-    assert tool.annotations.openWorldHint is True
-    assert tool.annotations.idempotentHint is None
-
-
-async def test_tool_metadata_orb_get_responsiveness():
-    tool = await mcp_server.mcp.get_tool("orb_get_responsiveness")
-    assert tool is not None
-    assert tool.title == "Get Responsiveness Dataset"
-    assert tool.tags == {"orb", "responsiveness"}
-    assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is True
-    assert tool.annotations.openWorldHint is True
-    assert tool.annotations.idempotentHint is None
-
-
-async def test_tool_metadata_orb_get_web_responsiveness():
-    tool = await mcp_server.mcp.get_tool("orb_get_web_responsiveness")
-    assert tool is not None
-    assert tool.title == "Get Web Responsiveness Dataset"
-    assert tool.tags == {"orb", "web-performance"}
-    assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is True
-    assert tool.annotations.openWorldHint is True
-    assert tool.annotations.idempotentHint is None
-
-
-async def test_tool_metadata_orb_get_speed_results():
-    tool = await mcp_server.mcp.get_tool("orb_get_speed_results")
-    assert tool is not None
-    assert tool.title == "Get Speed Test Results"
-    assert tool.tags == {"orb", "speed"}
-    assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is True
-    assert tool.annotations.openWorldHint is True
-    assert tool.annotations.idempotentHint is None
-
-
-async def test_tool_metadata_orb_get_wifi_link():
-    tool = await mcp_server.mcp.get_tool("orb_get_wifi_link")
-    assert tool is not None
-    assert tool.title == "Get Wi-Fi Link Dataset"
-    assert tool.tags == {"orb", "wifi"}
+    assert tool.title == expected_title
+    assert tool.tags == expected_tags
     assert tool.annotations is not None
     assert tool.annotations.readOnlyHint is True
     assert tool.annotations.openWorldHint is True
@@ -362,7 +336,7 @@ async def test_log_uses_resolved_host_not_raw_arg(mock_client, ctx):
     (from config), not literal 'None'."""
     mock_client.host = "resolved-host"
 
-    await mcp_server.orb_get_scores(ctx, host=None)
+    await mcp_server.orb_get_scores(ctx, host=None)  # ty: ignore[unresolved-attribute]
 
     ctx.info.assert_awaited_once()
     log_message = ctx.info.await_args.args[0]
@@ -502,7 +476,7 @@ class TestOrbGetScoresErrorEnvelope:
 
         mock_client.get_scores_1m.side_effect = httpx.ConnectError("conn refused")
 
-        result = await mcp_server.orb_get_scores(ctx, host="h")
+        result = await mcp_server.orb_get_scores(ctx, host="h")  # ty: ignore[unresolved-attribute]
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "sensor_unreachable"
@@ -521,7 +495,7 @@ class TestOrbGetResponsivenessErrorEnvelope:
             "404", request=request, response=response
         )
 
-        result = await mcp_server.orb_get_responsiveness(
+        result = await mcp_server.orb_get_responsiveness(  # ty: ignore[unresolved-attribute]
             ctx, host="h", granularity="1s"
         )
 
@@ -542,7 +516,7 @@ class TestOrbGetResponsivenessErrorEnvelope:
             "404", request=request, response=response
         )
 
-        result = await mcp_server.orb_get_responsiveness(
+        result = await mcp_server.orb_get_responsiveness(  # ty: ignore[unresolved-attribute]
             ctx, host="h", granularity="1m"
         )
 
@@ -565,7 +539,7 @@ class TestOrbGetWifiLinkErrorEnvelope:
             "404", request=request, response=response
         )
 
-        result = await mcp_server.orb_get_wifi_link(ctx, host="h", granularity="1s")
+        result = await mcp_server.orb_get_wifi_link(ctx, host="h", granularity="1s")  # ty: ignore[unresolved-attribute]
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "granularity_unavailable"
@@ -586,7 +560,7 @@ class TestOrbGetWebResponsivenessErrorEnvelope:
             "404", request=request, response=response
         )
 
-        result = await mcp_server.orb_get_web_responsiveness(ctx, host="h")
+        result = await mcp_server.orb_get_web_responsiveness(ctx, host="h")  # ty: ignore[unresolved-attribute]
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "dataset_not_found"
@@ -598,7 +572,7 @@ class TestOrbGetSpeedResultsErrorEnvelope:
 
         mock_client.get_speed_results.side_effect = httpx.TimeoutException("slow")
 
-        result = await mcp_server.orb_get_speed_results(ctx, host="h")
+        result = await mcp_server.orb_get_speed_results(ctx, host="h")  # ty: ignore[unresolved-attribute]
 
         assert isinstance(result, ErrorPayload)
         assert result.code == "timeout"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,15 +6,12 @@ import pytest
 from pydantic import ValidationError
 
 from orbnet.models import (
-    AllDatasetsRequestParams,
     AllDatasetsResponse,
-    DatasetRequestParams,
     NetworkDimensions,
     OrbClientConfig,
     PollingConfig,
     ResponsivenessMeasures,
     ResponsivenessRecord,
-    ResponsivenessRequestParams,
     ScoreIdentifiers,
     ScoreMeasures,
     ScoreRecord,
@@ -76,81 +73,6 @@ class TestOrbClientConfig:
             OrbClientConfig(host="192.168.1.100", timeout=0)
         with pytest.raises(ValidationError):
             OrbClientConfig(host="192.168.1.100", timeout=-1.0)
-
-
-class TestDatasetRequestParams:
-    """Test DatasetRequestParams model."""
-
-    def test_default_values(self):
-        """Test default parameter values."""
-        params = DatasetRequestParams()
-        assert params.caller_id is None
-
-    def test_custom_values(self):
-        """Test custom parameter values."""
-        params = DatasetRequestParams.model_validate(
-            {"caller_id": "test-caller", "extra_param": "extra_value"}
-        )
-        assert params.caller_id == "test-caller"
-        assert params.model_extra is not None
-        assert params.model_extra["extra_param"] == "extra_value"
-
-
-class TestResponsivenessRequestParams:
-    """Test ResponsivenessRequestParams model."""
-
-    def test_default_values(self):
-        """Test default parameter values."""
-        params = ResponsivenessRequestParams()
-        assert params.caller_id is None
-        assert params.granularity == "1m"
-
-    def test_custom_values(self):
-        """Test custom parameter values."""
-        params = ResponsivenessRequestParams(caller_id="test-caller", granularity="1s")
-        assert params.caller_id == "test-caller"
-        assert params.granularity == "1s"
-
-    def test_granularity_validation(self):
-        """Test granularity validation."""
-        # Valid granularities
-        ResponsivenessRequestParams(granularity="1s")
-        ResponsivenessRequestParams(granularity="15s")
-        ResponsivenessRequestParams(granularity="1m")
-
-        # Invalid granularity
-        with pytest.raises(ValidationError):
-            ResponsivenessRequestParams.model_validate({"granularity": "5m"})
-
-
-class TestAllDatasetsRequestParams:
-    """Test AllDatasetsRequestParams model."""
-
-    def test_default_values(self):
-        """Test default parameter values."""
-        params = AllDatasetsRequestParams()
-        assert params.caller_id is None
-        assert params.default_granularity == "1m"
-        assert params.include_all_responsiveness is False
-        assert params.include_all_wifi_link is False
-
-    def test_custom_values(self):
-        """Test custom parameter values."""
-        params = AllDatasetsRequestParams(
-            caller_id="test-caller",
-            default_granularity="1s",
-            include_all_responsiveness=True,
-            include_all_wifi_link=True,
-        )
-        assert params.caller_id == "test-caller"
-        assert params.default_granularity == "1s"
-        assert params.include_all_responsiveness is True
-        assert params.include_all_wifi_link is True
-
-    def test_invalid_default_granularity_raises(self):
-        """Test that invalid default_granularity raises ValidationError."""
-        with pytest.raises(ValidationError):
-            AllDatasetsRequestParams(default_granularity="5m")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
 
 
 class TestPollingConfig:


### PR DESCRIPTION
## Summary

Bundles candidates #2 and #3 of the four-PR architecture sweep. Makes `DatasetSpec` the single source of truth that both the Python API and the MCP server consult about a dataset family; collapses the five per-family `orb_get_*` MCP tool functions into one factory + five rows.

- `DatasetSpec` gains `tool_name: str` (e.g. `"orb_get_scores"`) and a `validate_granularity()` method.
- `OrbAPIClient._fetch` calls `spec.validate_granularity(g)` instead of inlining the check.
- `OrbAPIClient.get_all_datasets`'s partial-failure path reads `spec.tool_name` instead of looking up `FAMILY_TO_TOOL_NAME[spec.family]`. The hand-maintained table in `errors.py` is deleted.
- Five per-family `async def orb_get_*` MCP tool functions (~50 lines each) collapse into one `_register_dataset_tool` factory + five declarative rows. LLM-facing per-tool docstrings lift to module-level constants.
- Three unused-or-pass-through Pydantic shells deleted: `DatasetRequestParams`, `ResponsivenessRequestParams`, `AllDatasetsRequestParams`. Their validation behavior (Literal on granularity, bool coercion on flags, str|None on caller_id) is preserved via three `TypeAdapter` instances at the entry point.

## Motivation

The DATASETS registry already owned wire names, response fields, and record classes — but the MCP tool name and the granularity-validation logic lived elsewhere (a hand-maintained dict in `errors.py` and an inline check in `_fetch`). Add or rename a dataset family and you'd touch three files in lockstep. Now the registry is the single thing to edit; the MCP layer's per-family ceremony is one row in a side table.

## Behavior preserved

- Wire format and error envelope shape: unchanged.
- Public Python API method signatures (`get_*`, `poll_dataset`, `get_all_datasets`): unchanged.
- MCP tool surface (titles, tags, docstrings, output schemas, defaults, granularity-fallback semantics): unchanged. Five per-tool metadata tests collapse into one parametrized walk that asserts the same invariants.
- `OrbAPIClient(transport=...)` direct-invocation pattern: unchanged. The factory binds tools to module globals via `globals()[tool_name] = _tool` so `mcp_server.orb_get_scores(ctx, ...)` continues to be importable from tests.
- `AllDatasetsRequestParams`'s validation behavior: every behavior preserved via `_GRANULARITY_ADAPTER`, `_BOOL_ADAPTER`, `_CALLER_ID_ADAPTER`. New `TestGetAllDatasetsValidation` regression tests pin them (invalid granularity raises, `"false"` coerces to `False`, non-string `caller_id` raises).

## Behavior changes (intentional)

- `OrbAPIClient.get_all_datasets`'s `caller_id`/include-flag arguments now reach `_fetch`/the plan loop *after* `TypeAdapter.validate_python(...)` runs (instead of after Pydantic's model construction). Same `ValidationError` type for invalid inputs; same coerced bool values; same downstream behavior.

## Honest framing

The MCP tool factory's `globals()[tool_name] = _tool` binding is invisible to ty's static analyzer (it's a deliberate dynamic binding). Sixteen `# ty: ignore[unresolved-attribute]` suppressions in `tests/test_mcp_server.py` cover the gap. A registration-time `hasattr(OrbAPIClient, client_method_name)` guard catches typos in spec.family or missing client methods at module import (not first request).

## Test plan

- [x] `uv run pytest tests/ -q` → 236 passing
- [x] `uv run prek run --all-files --hook-stage pre-push` → all green (ruff check, ruff format, ty)
- [x] 100% coverage maintained
- [x] Independent Codex review on the plan (3 findings addressed) and on the implementation (1 follow-up addressed in `d14f4f5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)