### PR TITLE
refactor: collapse OrbClientConfig indirection

### DIFF
--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -28,6 +28,7 @@ _BOOL_ADAPTER: TypeAdapter[bool] = TypeAdapter(bool)
 _CALLER_ID_ADAPTER: TypeAdapter[str | None] = TypeAdapter(str | None)
 _HOST_ADAPTER: TypeAdapter[str] = TypeAdapter(Annotated[str, Field(min_length=1)])
 _PORT_ADAPTER: TypeAdapter[int] = TypeAdapter(Annotated[int, Field(ge=1, le=65535)])
+_STR_ADAPTER: TypeAdapter[str] = TypeAdapter(str)
 _TIMEOUT_ADAPTER: TypeAdapter[float] = TypeAdapter(Annotated[float, Field(gt=0)])
 
 logger = logging.getLogger(__name__)
@@ -115,9 +116,15 @@ class OrbAPIClient:
         """
         self.host: str = _HOST_ADAPTER.validate_python(host)
         self.port: int = _PORT_ADAPTER.validate_python(port)
-        self.caller_id: str = str(uuid.uuid4()) if caller_id is None else caller_id
+        self.caller_id: str = (
+            str(uuid.uuid4())
+            if caller_id is None
+            else _STR_ADAPTER.validate_python(caller_id)
+        )
         self.client_id: str = (
-            f"orbnet/{get_version('orbnet')}" if client_id is None else client_id
+            f"orbnet/{get_version('orbnet')}"
+            if client_id is None
+            else _STR_ADAPTER.validate_python(client_id)
         )
         self.timeout: float = _TIMEOUT_ADAPTER.validate_python(timeout)
         self._transport: DatasetTransport = (

--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -3,17 +3,16 @@ import inspect
 import logging
 import uuid
 from importlib.metadata import version as get_version
-from typing import Any, cast
+from typing import Annotated, Any
 
 import httpx
-from pydantic import TypeAdapter
+from pydantic import Field, TypeAdapter
 
 from .datasets import DATASETS, DatasetSpec, parse_poll_alias
 from .errors import ErrorContext, translate_exception
 from .models import (
     AllDatasetsResponse,
     Granularity,
-    OrbClientConfig,
     PollingCallback,
     PollingConfig,
     ResponsivenessRecord,
@@ -27,6 +26,9 @@ from .transport import DatasetTransport, HttpxDatasetTransport
 _GRANULARITY_ADAPTER: TypeAdapter[Granularity] = TypeAdapter(Granularity)
 _BOOL_ADAPTER: TypeAdapter[bool] = TypeAdapter(bool)
 _CALLER_ID_ADAPTER: TypeAdapter[str | None] = TypeAdapter(str | None)
+_HOST_ADAPTER: TypeAdapter[str] = TypeAdapter(Annotated[str, Field(min_length=1)])
+_PORT_ADAPTER: TypeAdapter[int] = TypeAdapter(Annotated[int, Field(ge=1, le=65535)])
+_TIMEOUT_ADAPTER: TypeAdapter[float] = TypeAdapter(Annotated[float, Field(gt=0)])
 
 logger = logging.getLogger(__name__)
 
@@ -86,8 +88,8 @@ class OrbAPIClient:
                        builds a default `HttpxDatasetTransport` from
                        host/port/client_id/timeout. The transport
                        snapshots these values at construction; mutating
-                       `self.config` post-init does not alter request
-                       target, headers, or timeout. (See
+                       attributes like `self.host` post-init does not
+                       alter request target, headers, or timeout. (See
                        `orbnet.transport` for the seam's current
                        httpx-shaped contract.)
 
@@ -111,57 +113,28 @@ class OrbAPIClient:
             ...     timeout=120.0
             ... )
         """
-        self.config = OrbClientConfig(
-            host=host,
-            port=port,
-            caller_id=str(uuid.uuid4()) if caller_id is None else caller_id,
-            client_id=(
-                f"orbnet/{get_version('orbnet')}" if client_id is None else client_id
-            ),
-            timeout=timeout,
+        self.host: str = _HOST_ADAPTER.validate_python(host)
+        self.port: int = _PORT_ADAPTER.validate_python(port)
+        self.caller_id: str = str(uuid.uuid4()) if caller_id is None else caller_id
+        self.client_id: str = (
+            f"orbnet/{get_version('orbnet')}" if client_id is None else client_id
         )
+        self.timeout: float = _TIMEOUT_ADAPTER.validate_python(timeout)
         self._transport: DatasetTransport = (
             transport
             if transport is not None
             else HttpxDatasetTransport(
-                host=self.config.host,
-                port=self.config.port,
-                client_id=cast(str, self.config.client_id),
-                timeout=self.config.timeout,
+                host=self.host,
+                port=self.port,
+                client_id=self.client_id,
+                timeout=self.timeout,
             )
         )
 
     @property
-    def host(self) -> str:
-        """Get the configured host"""
-        return self.config.host
-
-    @property
-    def port(self) -> int:
-        """Get the configured port"""
-        return self.config.port
-
-    @property
-    def caller_id(self) -> str:
-        """Get the configured caller_id"""
-        # __init__ always resolves caller_id to a non-None value before storing.
-        return cast(str, self.config.caller_id)
-
-    @property
-    def client_id(self) -> str:
-        """Get the configured client_id"""
-        # __init__ always resolves client_id to a non-None value before storing.
-        return cast(str, self.config.client_id)
-
-    @property
-    def timeout(self) -> float:
-        """Get the configured timeout"""
-        return self.config.timeout
-
-    @property
     def base_url(self) -> str:
         """Construct the base URL from host and port"""
-        return f"http://{self.config.host}:{self.config.port}"
+        return f"http://{self.host}:{self.port}"
 
     async def _fetch(
         self,
@@ -180,7 +153,7 @@ class OrbAPIClient:
         """
         spec.validate_granularity(granularity)
 
-        caller = caller_id or self.config.caller_id
+        caller = caller_id or self.caller_id
         raw_data = await self._transport.fetch_dataset(
             spec.wire_name(granularity),
             {"id": caller, **params},

--- a/src/orbnet/client.py
+++ b/src/orbnet/client.py
@@ -160,7 +160,7 @@ class OrbAPIClient:
         """
         spec.validate_granularity(granularity)
 
-        caller = caller_id or self.caller_id
+        caller = self.caller_id if caller_id is None else caller_id
         raw_data = await self._transport.fetch_dataset(
             spec.wire_name(granularity),
             {"id": caller, **params},

--- a/src/orbnet/models.py
+++ b/src/orbnet/models.py
@@ -22,29 +22,6 @@ NETWORK_STATE_DESC = (
 LOCATION_SOURCE_DESC = "Location Source: 0=unknown, 1=geoip (may not be included)"
 
 
-class OrbClientConfig(BaseModel):
-    """Configuration for the Orb API Client"""
-
-    host: str = Field(
-        min_length=1,
-        description="Hostname or IP address of the Orb sensor",
-    )
-    port: int = Field(
-        default=7080, ge=1, le=65535, description="Port number for the Orb API"
-    )
-    caller_id: str | None = Field(
-        default=None,
-        description="Unique ID for this caller to track polling state. If None, generates a random UUID.",  # noqa: E501
-    )
-    client_id: str | None = Field(
-        default=None,
-        description="Optional identifier for the HTTP client itself (sent as User-Agent header). If None, uses a default.",  # noqa: E501
-    )
-    timeout: float = Field(default=30.0, gt=0, description="Request timeout in seconds")
-
-    model_config = ConfigDict(validate_assignment=True)
-
-
 class PollingConfig(BaseModel):
     """Configuration for polling datasets"""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -744,9 +744,9 @@ class TestExplicitOverrideSemantics:
     """__init__ uses `is None` checks, not falsy fallbacks, so explicit
     empty-string overrides are honored rather than silently replaced.
 
-    The one exception is `host`, which has min_length=1 in OrbClientConfig
-    — an empty hostname produces a structurally invalid base URL like
-    `http://:7080`, so it's rejected at construction.
+    The one exception is `host`, which is validated by `_HOST_ADAPTER`
+    (min_length=1) — an empty hostname produces a structurally invalid
+    base URL like `http://:7080`, so it's rejected at construction.
     """
 
     def test_empty_host_is_rejected(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -778,6 +778,37 @@ class TestExplicitOverrideSemantics:
         assert client.client_id.startswith("orbnet/")
 
 
+class TestNonStringIdentifierRejection:
+    """OrbClientConfig (deleted in PR3) rejected non-string caller_id /
+    client_id via Pydantic's default strict-string typing. Inline TypeAdapter
+    validation in __init__ preserves that rejection."""
+
+    def test_non_string_caller_id_raises(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            OrbAPIClient(host="192.168.1.100", caller_id=42)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
+
+    def test_non_string_client_id_raises(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            OrbAPIClient(host="192.168.1.100", client_id=42)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]  # noqa: E501
+
+    def test_caller_id_none_still_generates_uuid(self):
+        """None bypasses the validator (default branch). Sanity check
+        that the validation didn't accidentally break the UUID default."""
+        client = OrbAPIClient(host="192.168.1.100", caller_id=None)
+        assert client.caller_id is not None
+        assert client.caller_id != ""
+
+    def test_client_id_none_still_uses_default(self):
+        """None bypasses the validator. Sanity check that the default
+        identifier path still works."""
+        client = OrbAPIClient(host="192.168.1.100", client_id=None)
+        assert client.client_id.startswith("orbnet/")
+
+
 class TestPollDatasetPropagatesProgrammingErrors:
     """poll_dataset only swallows transport (httpx) errors. Programming errors
     such as pydantic validation failures and callback bugs must propagate so

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -777,6 +777,15 @@ class TestExplicitOverrideSemantics:
         client = OrbAPIClient(host="192.168.1.100", client_id=None)
         assert client.client_id.startswith("orbnet/")
 
+    def test_port_above_max_is_rejected(self):
+        """port=65536 should raise ValidationError (above _PORT_ADAPTER's
+        le=65535 upper bound). Closes the boundary-coverage gap left by
+        the deleted TestOrbClientConfig.test_port_validation."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            OrbAPIClient(host="192.168.1.100", port=65536)
+
 
 class TestNonStringIdentifierRejection:
     """OrbClientConfig (deleted in PR3) rejected non-string caller_id /

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -591,6 +591,29 @@ class TestFetchHelper:
         # `id` is always populated alongside extra params.
         assert "id" in params
 
+    @pytest.mark.asyncio
+    async def test_fetch_honors_explicit_empty_string_caller_id(
+        self, sample_scores_data, fake_transport
+    ):
+        """An explicit empty-string caller_id override must reach the
+        transport unchanged. The public API uses None as the
+        \"use default\" sentinel; empty strings are real overrides
+        (per TestExplicitOverrideSemantics::test_empty_caller_id_is_preserved
+        on __init__)."""
+        from orbnet.datasets import DATASETS
+
+        fake_transport.responses["scores_1m"] = sample_scores_data
+
+        client = OrbAPIClient(
+            host="192.168.1.100",
+            caller_id="default-id",
+            transport=fake_transport,
+        )
+        await client._fetch(DATASETS["scores"], "1m", caller_id="")
+
+        params = fake_transport.calls[-1][1]
+        assert params["id"] == ""
+
 
 class TestGetAllDatasetsPlan:
     """Verify get_all_datasets dispatches to the right wire endpoints."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -71,20 +71,19 @@ class TestIntegration:
         """Test error handling across components."""
         from pydantic import ValidationError
 
-        from orbnet.models import OrbClientConfig
+        from orbnet.client import OrbAPIClient
 
-        # Test invalid configuration
+        # Invalid configuration is rejected at construction.
         with pytest.raises(ValidationError):
-            OrbClientConfig(host="test-host", port=0)  # Invalid port
-
+            OrbAPIClient(host="test-host", port=0)
         with pytest.raises(ValidationError):
-            OrbClientConfig(host="test-host", timeout=-1.0)  # Invalid timeout
+            OrbAPIClient(host="test-host", timeout=-1.0)
 
-        # Test valid configuration
-        config = OrbClientConfig(host="192.168.1.100", port=8080, timeout=30.0)
-        assert config.host == "192.168.1.100"
-        assert config.port == 8080
-        assert config.timeout == 30.0
+        # Valid configuration succeeds.
+        client = OrbAPIClient(host="192.168.1.100", port=8080, timeout=30.0)
+        assert client.host == "192.168.1.100"
+        assert client.port == 8080
+        assert client.timeout == 30.0
 
     @pytest.mark.slow
     @pytest.mark.asyncio
@@ -192,7 +191,6 @@ class TestIntegration:
         from orbnet.mcp_server import _get_client_info_impl
         from orbnet.models import (
             AllDatasetsResponse,
-            OrbClientConfig,
             ResponsivenessRecord,
             ScoreRecord,
             SpeedRecord,
@@ -202,11 +200,9 @@ class TestIntegration:
 
         # Test that they can be instantiated
         client = OrbAPIClient(host="192.168.1.100")
-        config = OrbClientConfig(host="192.168.1.100")
         info = _get_client_info_impl(host="192.168.1.100")
 
         assert client is not None
-        assert config is not None
         assert info is not None
 
         # Verify record types are available

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,6 @@ from pydantic import ValidationError
 from orbnet.models import (
     AllDatasetsResponse,
     NetworkDimensions,
-    OrbClientConfig,
     PollingConfig,
     ResponsivenessMeasures,
     ResponsivenessRecord,
@@ -22,57 +21,6 @@ from orbnet.models import (
     WifiLinkMeasures,
     WifiLinkRecord,
 )
-
-
-class TestOrbClientConfig:
-    """Test OrbClientConfig model."""
-
-    def test_default_values(self):
-        """Test default configuration values."""
-        config = OrbClientConfig(host="192.168.1.100")
-        assert config.host == "192.168.1.100"
-        assert config.port == 7080
-        assert config.caller_id is None
-        assert config.client_id is None
-        assert config.timeout == 30.0
-
-    def test_custom_values(self):
-        """Test custom configuration values."""
-        config = OrbClientConfig(
-            host="192.168.1.100",
-            port=8080,
-            caller_id="test-caller",
-            client_id="test-client",
-            timeout=60.0,
-        )
-        assert config.host == "192.168.1.100"
-        assert config.port == 8080
-        assert config.caller_id == "test-caller"
-        assert config.client_id == "test-client"
-        assert config.timeout == 60.0
-
-    def test_port_validation(self):
-        """Test port number validation."""
-        # Valid ports
-        OrbClientConfig(host="192.168.1.100", port=1)
-        OrbClientConfig(host="192.168.1.100", port=65535)
-
-        # Invalid ports
-        with pytest.raises(ValidationError):
-            OrbClientConfig(host="192.168.1.100", port=0)
-        with pytest.raises(ValidationError):
-            OrbClientConfig(host="192.168.1.100", port=65536)
-
-    def test_timeout_validation(self):
-        """Test timeout validation."""
-        # Valid timeout
-        OrbClientConfig(host="192.168.1.100", timeout=0.1)
-
-        # Invalid timeout
-        with pytest.raises(ValidationError):
-            OrbClientConfig(host="192.168.1.100", timeout=0)
-        with pytest.raises(ValidationError):
-            OrbClientConfig(host="192.168.1.100", timeout=-1.0)
 
 
 class TestPollingConfig:


### PR DESCRIPTION
## Summary

Final PR (#4) of the four-PR architecture sweep. Removes the `OrbClientConfig` Pydantic model from `orbnet.models` and the 5 pass-through `@property` accessors on `OrbAPIClient` (`host`, `port`, `caller_id`, `client_id`, `timeout`). Lifts those fields directly onto the client as honestly-typed real attributes, validated inline via `TypeAdapter`.

- `OrbAPIClient.__init__` now validates `host`/`port`/`timeout` via three module-level `TypeAdapter` instances (`_HOST_ADAPTER`, `_PORT_ADAPTER`, `_TIMEOUT_ADAPTER`) and validates `caller_id`/`client_id` via `_STR_ADAPTER` for the explicit-value branch.
- The 5 pass-through `@property` definitions delete entirely. The 2 `cast(str, self.config.<id>)` workarounds (forced by `OrbClientConfig` typing `caller_id`/`client_id` as `str | None` while `__init__` always resolved to non-None) delete with them.
- `base_url` survives as a derived `@property` (not pass-through — it's a small computed value; the right shape for an inline derivation).
- `OrbClientConfig` deletes from `models.py` along with its tests. Was never re-exported from `orbnet/__init__.py` so this has no public-API impact.

## Motivation

`OrbClientConfig` was a Pydantic model whose fields were exactly the `OrbAPIClient`'s configuration — except the model typed `caller_id`/`client_id` as `str | None` (since None was the documented "use default" sentinel for the constructor) while every property accessor had to `cast(str, ...)` because `__init__` always resolved them to non-None before storing. Five pass-through properties + two casts for the price of declarative validation that could be expressed inline. The refactor lifts the fields onto the client directly, validates inline, and stores honestly-typed real attributes.

## Behavior preserved

- Public Python API surface unchanged: `client.host`, `client.port`, `client.base_url`, `client.caller_id`, `client.client_id`, `client.timeout` all still work — now as real `str`/`int`/`float` attributes (or one derived `@property`).
- `pydantic.ValidationError` raised for invalid host/port/timeout (TypeAdapter raises it) — same exception type as before.
- `pydantic.ValidationError` raised for non-string `caller_id`/`client_id` (`_STR_ADAPTER` raises it) — preserves what `OrbClientConfig.<id>: str | None` typing did.
- `is None` semantics preserved: explicit `None` for `caller_id`/`client_id` triggers the default branch (UUID / `orbnet/<version>`); explicit empty strings are honored as overrides.
- Wire format, error envelope shape, MCP tool surface, transport seam all unchanged.

## Behavior changes (intentional)

- `validate_assignment=True` from `OrbClientConfig.model_config` is gone. Setting `client.host = "x"` post-init no longer triggers re-validation. PR1 already documented that `client.config` mutation didn't affect requests anyway (transport snapshots config at construction); now there's no `client.config` to mutate. No call sites in src/ or tests/ were doing this.

## Test plan

- [x] `uv run pytest tests/ -q` → 237 passing
- [x] `uv run prek run --all-files --hook-stage pre-push` → all green (ruff check, ruff format, ty)
- [x] 100% coverage maintained
- [x] Independent Codex review on the plan (2 findings addressed) and on the implementation (1 mid-implementation finding addressed in `3e46026`; final review confirmed all closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)